### PR TITLE
Fix quick-start URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Welcome to the repository for the main Stroom application. The application spans several repositories but we've bundled all the documentation into the [`stroom-docs` repository](http://github.com/gchq/stroom-docs). That's where to look if you want any of these:
 
 - [The main README.md](http://github.com/gchq/stroom-docs/blob/master/README.md)
-- [The quick-start guide](http://github.com/gchq/stroom-docs/blod/master/quick-start-guide/quick-start.md)
+- [The quick-start guide](http://github.com/gchq/stroom-docs/blob/master/quick-start-guide/quick-start.md)
 - [The developer guide](http://github.com/gchq/stroom-docs/tree/master/dev-guide/)
 - [The install guide](http://github.com/gchq/stroom-docs/tree/master/install-guide)
 - [The user guide](http://github.com/gchq/stroom-docs/tree/master/user-guide)


### PR DESCRIPTION
The README had a typo - s/blod/blob. Fixes.