### PR TITLE
Prefer URLs which use TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
 # ![Stroom](logo.png)
 
-Welcome to the repository for the main Stroom application. The application spans several repositories but we've bundled all the documentation into the [`stroom-docs` repository](http://github.com/gchq/stroom-docs). That's where to look if you want any of these:
+Welcome to the repository for the main Stroom application. The application spans several repositories but we've bundled all the documentation into the [`stroom-docs` repository](https://github.com/gchq/stroom-docs). That's where to look if you want any of these:
 
-- [The main README.md](http://github.com/gchq/stroom-docs/blob/master/README.md)
-- [The quick-start guide](http://github.com/gchq/stroom-docs/blob/master/quick-start-guide/quick-start.md)
-- [The developer guide](http://github.com/gchq/stroom-docs/tree/master/dev-guide/)
-- [The install guide](http://github.com/gchq/stroom-docs/tree/master/install-guide)
-- [The user guide](http://github.com/gchq/stroom-docs/tree/master/user-guide)
+- [The main README.md](https://github.com/gchq/stroom-docs/blob/master/README.md)
+- [The quick-start guide](https://github.com/gchq/stroom-docs/blob/master/quick-start-guide/quick-start.md)
+- [The developer guide](https://github.com/gchq/stroom-docs/tree/master/dev-guide/)
+- [The install guide](https://github.com/gchq/stroom-docs/tree/master/install-guide)
+- [The user guide](https://github.com/gchq/stroom-docs/tree/master/user-guide)
 
 If you'd like to make a contribution then the details for doing all of that are in [CONTRIBUTING.md](https://github.com/gchq/stroom/blob/master/CONTRIBUTING.md).
 
 Stroom spans several repositories:
 
-- [`stroom`     ](http://github.com/gchq/stroom)
-- [`stroom-proxy`](http://github.com/gchq/stroom-proxy)
-- [`stroom-agent`](http://github.com/gchq/stroom-agent)
-- [`stroom-docs`](http://github.com/gchq/stroom-docs)
-- [`stroom-visualisations-dev`](http://github.com/gchq/stroom-visualisations-dev)
-- [`stroom-content`           ](http://github.com/gchq/stroom-content)
-- [`stroom-releases`          ](http://github.com/gchq/stroom-releases)
-- [`stroom-clients`           ](http://github.com/gchq/stroom-clients)
-- [`event-logging`            ](http://github.com/gchq/event-logging)
-- [`event-logging-schema`     ](http://github.com/gchq/event-logging-schema)
+- [`stroom`     ](https://github.com/gchq/stroom)
+- [`stroom-proxy`](https://github.com/gchq/stroom-proxy)
+- [`stroom-agent`](https://github.com/gchq/stroom-agent)
+- [`stroom-docs`](https://github.com/gchq/stroom-docs)
+- [`stroom-visualisations-dev`](https://github.com/gchq/stroom-visualisations-dev)
+- [`stroom-content`           ](https://github.com/gchq/stroom-content)
+- [`stroom-releases`          ](https://github.com/gchq/stroom-releases)
+- [`stroom-clients`           ](https://github.com/gchq/stroom-clients)
+- [`event-logging`            ](https://github.com/gchq/event-logging)
+- [`event-logging-schema`     ](https://github.com/gchq/event-logging-schema)
 
     


### PR DESCRIPTION
I'm sure GitHub uses HTTP Strict Transport Security, but let's encourage TLS everywhere.