### PR TITLE
detaching entities before copy

### DIFF
--- a/stroom-core-server/src/main/java/stroom/entity/server/CachingEntityManager.java
+++ b/stroom-core-server/src/main/java/stroom/entity/server/CachingEntityManager.java
@@ -115,6 +115,11 @@ public class CachingEntityManager implements StroomEntityManager, Clearable {
     }
 
     @Override
+    public <T extends Entity> void detach(final T entity) {
+        stroomEntityManager.detach(entity);
+    }
+
+    @Override
     public Long executeNativeUpdate(final SqlBuilder sql) {
         return stroomEntityManager.executeNativeUpdate(sql);
     }

--- a/stroom-core-server/src/main/java/stroom/entity/server/DocumentEntityServiceImpl.java
+++ b/stroom-core-server/src/main/java/stroom/entity/server/DocumentEntityServiceImpl.java
@@ -58,7 +58,9 @@ import java.util.stream.Collectors;
 public abstract class DocumentEntityServiceImpl<E extends DocumentEntity, C extends FindDocumentEntityCriteria> implements DocumentEntityService<E>, BaseEntityService<E>, FindService<E, C>, ProvidesNamePattern {
     public static final String FOLDER = ExplorerConstants.FOLDER;
     private static final String NAME_PATTERN_PROPERTY = "stroom.namePattern";
+    private static final String NAME_COPY_PATTERN_PROPERTY = "stroom.nameCopyPattern";
     private static final String NAME_PATTERN_VALUE = "^[a-zA-Z0-9_\\- \\.\\(\\)]{1,}$";
+    public static final String NAME_COPY_PATTERN_VALUE = "Copy of %s";
     public static final String ID = "@ID@";
     public static final String TYPE = "@TYPE@";
     public static final String NAME = "@NAME@";
@@ -327,8 +329,10 @@ public abstract class DocumentEntityServiceImpl<E extends DocumentEntity, C exte
 
             document.setUuid(UUID.randomUUID().toString());
 
+            // Create a safe copy name
+            final String name = String.format(getNameCopyPattern(), document.getName());
+
             // Validate the entity name.
-            final String name = "Copy of " + document.getName();
             NameValidationUtil.validate(getNamePattern(), name);
             document.setName(name);
 
@@ -455,6 +459,12 @@ public abstract class DocumentEntityServiceImpl<E extends DocumentEntity, C exte
     @Override
     public String getNamePattern() {
         return StroomProperties.getProperty(NAME_PATTERN_PROPERTY, NAME_PATTERN_VALUE);
+    }
+
+    @Transient
+    @Override
+    public String getNameCopyPattern() {
+        return StroomProperties.getProperty(NAME_COPY_PATTERN_PROPERTY, NAME_COPY_PATTERN_VALUE);
     }
 
     private String getDocReference(BaseEntity entity) {

--- a/stroom-core-server/src/main/java/stroom/entity/server/DocumentEntityServiceImpl.java
+++ b/stroom-core-server/src/main/java/stroom/entity/server/DocumentEntityServiceImpl.java
@@ -314,8 +314,11 @@ public abstract class DocumentEntityServiceImpl<E extends DocumentEntity, C exte
         return success;
     }
 
-    private E copy(final E document, final String name, final String parentFolderUUID) {
+    private E copy(final E document, final String parentFolderUUID) {
         try {
+            // Ensure we are working with effectively a 'new document'
+            entityManager.detach(document);
+
             // Check create permissions of the parent folder.
             checkCreatePermission(parentFolderUUID);
 
@@ -325,6 +328,7 @@ public abstract class DocumentEntityServiceImpl<E extends DocumentEntity, C exte
             document.setUuid(UUID.randomUUID().toString());
 
             // Validate the entity name.
+            final String name = "Copy of " + document.getName();
             NameValidationUtil.validate(getNamePattern(), name);
             document.setName(name);
 
@@ -488,7 +492,8 @@ public abstract class DocumentEntityServiceImpl<E extends DocumentEntity, C exte
         if (entity == null) {
             throw new EntityServiceException("Entity not found");
         }
-        return DocRefUtil.create(copy(entity, "Copy of " + entity.getName(), parentFolderUUID));
+        final E copy = copy(entity, parentFolderUUID);
+        return DocRefUtil.create(copy);
     }
 
     @Override

--- a/stroom-core-server/src/main/java/stroom/entity/server/NamedEntityServiceImpl.java
+++ b/stroom-core-server/src/main/java/stroom/entity/server/NamedEntityServiceImpl.java
@@ -36,6 +36,8 @@ public abstract class NamedEntityServiceImpl<E extends NamedEntity, C extends Fi
         extends SystemEntityServiceImpl<E, C> implements NamedEntityService<E> {
     public static final String NAME_PATTERN_PROPERTY = "stroom.namePattern";
     public static final String NAME_PATTERN_VALUE = "^[a-zA-Z0-9_\\- \\.\\(\\)]{1,}$";
+    public static final String NAME_COPY_PATTERN_PROPERTY = "stroom.nameCopyPattern";
+    public static final String NAME_COPY_PATTERN_VALUE = "Copy of %s";
 
     protected NamedEntityServiceImpl(final StroomEntityManager entityManager) {
         super(entityManager);
@@ -96,6 +98,12 @@ public abstract class NamedEntityServiceImpl<E extends NamedEntity, C extends Fi
     @Override
     public String getNamePattern() {
         return StroomProperties.getProperty(NAME_PATTERN_PROPERTY, NAME_PATTERN_VALUE);
+    }
+
+    @Transient
+    @Override
+    public String getNameCopyPattern() {
+        return StroomProperties.getProperty(NAME_COPY_PATTERN_PROPERTY, NAME_COPY_PATTERN_VALUE);
     }
 
     @Override

--- a/stroom-core-server/src/main/java/stroom/entity/server/util/StroomEntityManager.java
+++ b/stroom-core-server/src/main/java/stroom/entity/server/util/StroomEntityManager.java
@@ -34,6 +34,8 @@ public interface StroomEntityManager extends Flushable {
 
     <T extends Entity> Boolean deleteEntity(T entity);
 
+    <T extends Entity> void detach(T entity);
+
     Long executeNativeUpdate(SqlBuilder sql);
 
     long executeNativeQueryLongResult(SqlBuilder sql);

--- a/stroom-core-server/src/main/java/stroom/entity/server/util/StroomEntityManagerImpl.java
+++ b/stroom-core-server/src/main/java/stroom/entity/server/util/StroomEntityManagerImpl.java
@@ -248,6 +248,13 @@ public class StroomEntityManagerImpl implements StroomEntityManager, BeanFactory
     }
 
     @Override
+    public <T extends Entity> void detach(final T entity) {
+        if (entityManager.contains(entity)) {
+            entityManager.detach(entity);
+        }
+    }
+
+    @Override
     public void flush() {
         entityManager.flush();
     }

--- a/stroom-core-server/src/main/java/stroom/feed/server/FeedServiceImpl.java
+++ b/stroom-core-server/src/main/java/stroom/feed/server/FeedServiceImpl.java
@@ -44,6 +44,8 @@ import java.util.Set;
 public class FeedServiceImpl extends DocumentEntityServiceImpl<Feed, FindFeedCriteria> implements FeedService {
     private static final String FEED_NAME_PATTERN_PROPERTY = "stroom.feedNamePattern";
     private static final String FEED_NAME_PATTERN_VALUE = "^[A-Z0-9_\\-]{3,}$";
+    private static final String FEED_NAME_COPY_PATTERN_PROPERTY = "stroom.feedNameCopyPattern";
+    private static final String FEED_NAME_COPY_PATTERN_VALUE = "COPY_OF_%s";
     private static final Set<String> FETCH_SET = Collections.singleton(StreamType.ENTITY_TYPE);
 
     @Inject
@@ -98,6 +100,12 @@ public class FeedServiceImpl extends DocumentEntityServiceImpl<Feed, FindFeedCri
     @Override
     public String getNamePattern() {
         return StroomProperties.getProperty(FEED_NAME_PATTERN_PROPERTY, FEED_NAME_PATTERN_VALUE);
+    }
+
+    @Transient
+    @Override
+    public String getNameCopyPattern() {
+        return StroomProperties.getProperty(FEED_NAME_COPY_PATTERN_PROPERTY, FEED_NAME_COPY_PATTERN_VALUE);
     }
 
     @Override

--- a/stroom-entity-shared/src/main/java/stroom/entity/shared/ProvidesNamePattern.java
+++ b/stroom-entity-shared/src/main/java/stroom/entity/shared/ProvidesNamePattern.java
@@ -19,5 +19,8 @@ package stroom.entity.shared;
 public interface ProvidesNamePattern {
     String getNamePattern();
 
-    String getNameCopyPattern();
+    // Provide a string that can be used with String.format to provide a safe copy
+    default String getNameCopyPattern() {
+        return "%s_copy";
+    }
 }

--- a/stroom-entity-shared/src/main/java/stroom/entity/shared/ProvidesNamePattern.java
+++ b/stroom-entity-shared/src/main/java/stroom/entity/shared/ProvidesNamePattern.java
@@ -18,4 +18,6 @@ package stroom.entity.shared;
 
 public interface ProvidesNamePattern {
     String getNamePattern();
+
+    String getNameCopyPattern();
 }

--- a/stroom-security-server/src/main/java/stroom/security/server/UserServiceImpl.java
+++ b/stroom-security-server/src/main/java/stroom/security/server/UserServiceImpl.java
@@ -56,6 +56,8 @@ import java.util.UUID;
 public class UserServiceImpl implements UserService {
     private static final String USER_NAME_PATTERN_PROPERTY = "stroom.security.userNamePattern";
     private static final String USER_NAME_PATTERN_VALUE = "^[a-zA-Z0-9_-]{3,}$";
+    private static final String USER_NAME_COPY_PATTERN_PROPERTY = "stroom.security.userNameCopyPattern";
+    private static final String USER_NAME_COPY_PATTERN_VALUE = "copy.%s";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UserServiceImpl.class);
     private static final String SQL_ADD_USER_TO_GROUP;
@@ -344,6 +346,12 @@ public class UserServiceImpl implements UserService {
     @Override
     public String getNamePattern() {
         return StroomProperties.getProperty(USER_NAME_PATTERN_PROPERTY, USER_NAME_PATTERN_VALUE);
+    }
+
+    @Transient
+    @Override
+    public String getNameCopyPattern() {
+        return StroomProperties.getProperty(USER_NAME_COPY_PATTERN_PROPERTY, USER_NAME_COPY_PATTERN_VALUE);
     }
 
     @Override

--- a/stroom-util/src/test/java/stroom/util/config/TestStroomProperties.java
+++ b/stroom-util/src/test/java/stroom/util/config/TestStroomProperties.java
@@ -40,9 +40,25 @@ public class TestStroomProperties {
     }
 
     @Test
-    public void test() {
+    public void testSimple() {
         String propertyName = "stroom.advertisedUrl";
         String environmentVariableName = CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, propertyName.replace('.', '_'));
         Assert.assertEquals("STROOM_ADVERTISED_URL", environmentVariableName);
+    }
+
+    @Test
+    public void testDocRefEntity() {
+        String propertyName = "stroom.url.doc-ref.service.AnnotationsIndex";
+        String environmentVariableName = CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, propertyName.replace('.', '_'));
+        Assert.assertEquals("STROOM_URL_DOC-REF_SERVICE__ANNOTATIONS_INDEX", environmentVariableName);
+    }
+
+    @Test
+    public void testDocRefList() {
+        String propertyName = "stroom.doc-ref.types";
+        String environmentVariableName = CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, propertyName.replace('.', '_'));
+        Assert.assertEquals("STROOM_DOC-REF_TYPES", environmentVariableName);
+
+
     }
 }


### PR DESCRIPTION
ensuring that existing entities are detached from hibernate before being copied

Any copies are prepended with 'Copy of' regardless of destination folder, whilst it might be nice to give it the original name if the folder is different...this would require more work, potentially querying the folder table. The copy can be renamed 'back' if required