### PR TITLE
gh-761 Change flowable in SSSTH to use an item vs time based window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+* Issue **#761** : New fix for premature truncation of SQL stats queries due to thread interruption.
+
 ## [v5.3.2] - 2018-05-11
 
 * Issue **#761** : Fixed statistic searches failing to search more than once.

--- a/stroom-core-server/src/main/java/stroom/node/server/DefaultProperties.java
+++ b/stroom-core-server/src/main/java/stroom/node/server/DefaultProperties.java
@@ -941,6 +941,12 @@ public class DefaultProperties {
                 .editable(true)
                 .build());
         list.add(new GlobalProperty.Builder()
+                .name("stroom.statistics.sql.search.resultHandlerBatchSize")
+                .value("5000")
+                .description("The number of database rows to pass to the result handler")
+                .editable(true)
+                .build());
+        list.add(new GlobalProperty.Builder()
                 .name("stroom.statistics.sql.maxProcessingAge")
                 .value("")
                 .description("The maximum age (e.g. '90d') of statistics to process and retain, i.e. any statistics with an statistic event time older than the current time minus maxProcessingAge will be silently dropped.  Existing statistic data over this age will be purged during statistic aggregation. Leave blank to process/retain all data.")

--- a/stroom-statistics-server/src/main/java/stroom/statistics/server/common/search/StatisticsSearchServiceImpl.java
+++ b/stroom-statistics-server/src/main/java/stroom/statistics/server/common/search/StatisticsSearchServiceImpl.java
@@ -387,6 +387,10 @@ class StatisticsSearchServiceImpl implements StatisticsSearchService {
                                         }
                                     },
                                     (rs, emitter) -> {
+                                        // The line below can be un-commented in development debugging to slow down the
+                                        // return of all results to test iterative results and dashboard polling.
+                                        // LockSupport.parkNanos(50_000);
+
                                         //advance the resultSet, if it is a row emit it, else finish the flow
                                         if (taskMonitor.isTerminated() || Thread.currentThread().isInterrupted()) {
                                             LOGGER.debug("Task is terminated/interrupted, calling onComplete");


### PR DESCRIPTION
An item based window does not use a separate thread. The interruption
of the window thread is casuing problems with the result handler
and loss of data.

Addresses #761 