### PR TITLE
added a unit test that demonstrates functionality of date string in repositoryFormat

### DIFF
--- a/stroom-core-server/src/test/java/stroom/proxy/repo/TestStroomZipRepository.java
+++ b/stroom-core-server/src/test/java/stroom/proxy/repo/TestStroomZipRepository.java
@@ -12,6 +12,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.FileTime;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -128,6 +130,39 @@ public class TestStroomZipRepository {
             Assert.assertTrue(1L == min);
             Assert.assertTrue(1L == max);
         });
+    }
+
+    @Test
+    public void testTemplatedFilenameWithDate() throws IOException {
+        // template should be case insensitive as far as key names go as the metamap is case insensitive
+        final String repositoryFormat = "${year}-${month}-${day}/${feed}/${id}";
+        final String FEED_NAME = "myFeed";
+
+        final String repoDir = FileUtil.getCanonicalPath(Files.createTempDirectory("stroom").resolve("repo3"));
+        StroomZipRepository stroomZipRepository = new StroomZipRepository(repoDir, repositoryFormat, false, 10000);
+
+        MetaMap metaMap = new MetaMap();
+        metaMap.put("feed", FEED_NAME);
+
+        final StroomZipOutputStreamImpl out1 = (StroomZipOutputStreamImpl) stroomZipRepository.getStroomZipOutputStream(metaMap);
+
+        StroomZipOutputStreamUtil.addSimpleEntry(out1, new StroomZipEntry(null, "file", StroomZipFileType.Data),
+                "SOME_DATA".getBytes(CharsetConstants.DEFAULT_CHARSET));
+        Assert.assertFalse(Files.isRegularFile(out1.getFile()));
+        out1.close();
+        Path zipFile = out1.getFile();
+        Path feedDir = zipFile.getParent();
+        Path dateDir = feedDir.getParent();
+        String dateDirStr = dateDir.getFileName().toString();
+
+        Assert.assertTrue(Files.isRegularFile(zipFile));
+
+        Assert.assertEquals(FEED_NAME, feedDir.getFileName().toString());
+
+        String pattern = "yyyy-MM-dd";
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat(pattern);
+        String nowStr = simpleDateFormat.format(new Date());
+        Assert.assertEquals(nowStr, dateDirStr);
     }
 
     @Test


### PR DESCRIPTION
There was a bug on our 6.0 project backlog, but it has either been fixed or I have misunderstood its nature. I have added a test that uses the date in the repository filename and all seems well