### PR TITLE
Change start script to use absolute paths for jar, config and logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+* Change start script to use absolute paths for jar, config and logs to distinguish stroom and proxy instances.
+
 * Change Travis build to generate sha256 hashes for release zip/jars.
 
 * Uplift the visualisations content pack to v3.2.1

--- a/stroom-app/src/dist/start.sh
+++ b/stroom-app/src/dist/start.sh
@@ -47,7 +47,8 @@ kill_log_tailing() {
 
 wait_for_200_response() {
     if [[ $# -ne 1 ]]; then
-        echo -e "${RED}Invalid arguments to wait_for_200_response(), expecting a URL to wait for${NC}"
+        echo -e "${RED}Invalid arguments to wait_for_200_response(), expecting" \
+          "a URL to wait for${NC}"
         exit 1
     fi
 
@@ -72,7 +73,8 @@ wait_for_200_response() {
     #printf "\n"
 
     if [[ $n -ge ${maxWaitSecs} ]]; then
-        warn "Gave up wating for stroom to start up, this may be due to the database migration taking a long time."
+        warn "Gave up wating for stroom to start up, this may be due to the" \
+          "database migration taking a long time."
     fi
 }
 
@@ -81,12 +83,26 @@ start_stroom() {
 
   info "Starting ${GREEN}Stroom${NC}"
   ensure_file_exists "${path_to_start_log}" 
-  ensure_file_exists "${PATH_TO_APP_LOG}" 
-  # We need word splitting so we need to disable SC2086
+
+  # stroom and proxy both use this script and the same jar so use absolute
+  # paths to distinguish the two processes when using the 'ps' command.
+  # Also makes it explicit about what files are being used.
+  local absolute_path_to_config
+  absolute_path_to_config="$(realpath "${PATH_TO_CONFIG}")"
+  local absoulte_path_to_jar
+  absoulte_path_to_jar="$(realpath "${PATH_TO_JAR}")"
+  local absolute_path_to_app_log
+  absolute_path_to_app_log="$(realpath "${PATH_TO_APP_LOG}")"
+  ensure_file_exists "${absolute_path_to_app_log}" 
+
+  # We need word splitting on JAVA_OPTS so we need to disable SC2086
   # shellcheck disable=SC2086
   nohup \
-    java ${JAVA_OPTS} -jar "${PATH_TO_JAR}" server "${PATH_TO_CONFIG}" \
-    &> "${PATH_TO_APP_LOG}" &
+    java ${JAVA_OPTS} \
+    -jar "${absoulte_path_to_jar}" \
+    server \
+    "${absolute_path_to_config}" \
+    &> "${absolute_path_to_app_log}" &
 
   local stroom_pid="$!"
   info "Started ${GREEN}Stroom${NC} with PID ${BLUE}${stroom_pid}${NC}"
@@ -94,7 +110,8 @@ start_stroom() {
   echo "${stroom_pid}" > "${STROOM_PID_FILE}"
 
   # tail the log in the background
-  info "Tailing log files ${BLUE}${path_to_start_log}${NC} and ${BLUE}${PATH_TO_APP_LOG}${NC}"
+  info "Tailing log files ${BLUE}${path_to_start_log}${NC} and" \
+    "${BLUE}${PATH_TO_APP_LOG}${NC}"
   tail -F "${path_to_start_log}" "${PATH_TO_APP_LOG}" 2>/dev/null &
   local tailing_pid="$!"
 
@@ -123,11 +140,14 @@ check_or_create_pid_file() {
     else 
       if ps -p "${PID}" > /dev/null # Check if the PID is a running process
       then
-        warn "Stroom is already running (pid: ${BLUE}$PID${NC}). Use ${BLUE}restart.sh${NC} if you want to start it."
+        warn "Stroom is already running (pid: ${BLUE}$PID${NC}). Use" \
+          "{BLUE}restart.sh${NC} if you want to start it."
         # echo -e "${RED}Warning:${NC} ${GREEN}Stroom${NC} is already running (pid: ${BLUE}$PID${NC}). Use ${BLUE}restart.sh${NC} if you want to start it."
       else 
         warn "There was an instance of Stroom running but it looks like"\
-          "it wasn't stopped gracefully. You might want to check the logs. If you are certain it is not running delete the file ${BLUE}${STROOM_PID_FILE}${NC}"
+          "it wasn't stopped gracefully. You might want to check the logs." \
+          "If you are certain it is not running delete the file" \
+          "${BLUE}${STROOM_PID_FILE}${NC}"
 
         read -n1 -r -p \
           " - Would you like to start a new instance? (y/n)" start_new_instance

--- a/stroom-app/src/dist/start.sh
+++ b/stroom-app/src/dist/start.sh
@@ -83,6 +83,7 @@ start_stroom() {
 
   info "Starting ${GREEN}Stroom${NC}"
   ensure_file_exists "${path_to_start_log}" 
+  ensure_file_exists "${PATH_TO_APP_LOG}" 
 
   # stroom and proxy both use this script and the same jar so use absolute
   # paths to distinguish the two processes when using the 'ps' command.
@@ -91,9 +92,6 @@ start_stroom() {
   absolute_path_to_config="$(realpath "${PATH_TO_CONFIG}")"
   local absoulte_path_to_jar
   absoulte_path_to_jar="$(realpath "${PATH_TO_JAR}")"
-  local absolute_path_to_app_log
-  absolute_path_to_app_log="$(realpath "${PATH_TO_APP_LOG}")"
-  ensure_file_exists "${absolute_path_to_app_log}" 
 
   # We need word splitting on JAVA_OPTS so we need to disable SC2086
   # shellcheck disable=SC2086
@@ -102,7 +100,7 @@ start_stroom() {
     -jar "${absoulte_path_to_jar}" \
     server \
     "${absolute_path_to_config}" \
-    &> "${absolute_path_to_app_log}" &
+    &> "${PATH_TO_APP_LOG}" &
 
   local stroom_pid="$!"
   info "Started ${GREEN}Stroom${NC} with PID ${BLUE}${stroom_pid}${NC}"


### PR DESCRIPTION
This makes is easier to distinguish stroom and proxy instances on a host