### PR TITLE
Change kafka config serialisation to use JsonTypeInfo.Id.NAME

### DIFF
--- a/stroom-app/src/test/java/stroom/kafka/impl/TestKafkaConfigSerialiser.java
+++ b/stroom-app/src/test/java/stroom/kafka/impl/TestKafkaConfigSerialiser.java
@@ -1,5 +1,6 @@
 package stroom.kafka.impl;
 
+import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -51,7 +52,7 @@ public class TestKafkaConfigSerialiser {
     }
 
     @Test
-    void name() throws IOException {
+    void testSerialiseDeserialise() throws IOException {
 
         KafkaConfigDoc kafkaConfigDoc = new KafkaConfigDoc();
         kafkaConfigDoc.setDescription("My description");
@@ -61,7 +62,8 @@ public class TestKafkaConfigSerialiser {
         kafkaConfigDoc.addProperty("Long", 123L);
         kafkaConfigDoc.addProperty("BooleanTrue", true);
         kafkaConfigDoc.addProperty("BooleanFalse", false);
-        kafkaConfigDoc.addProperty("Class", Object.class);
+        kafkaConfigDoc.addProperty("Class1", Object.class);
+        kafkaConfigDoc.addProperty("Class2", GoodClass.class);
         kafkaConfigDoc.addProperty("String", "A string");
 
         final Map<String, byte[]> data = serialiser.write(kafkaConfigDoc);
@@ -74,5 +76,69 @@ public class TestKafkaConfigSerialiser {
 
         Assertions.assertThat(kafkaConfigDoc)
                 .isEqualTo(kafkaConfigDoc2);
+
+        Assertions.assertThat(kafkaConfigDoc2.getProperties().get("Class2"))
+                .isInstanceOf(Class.class);
+        Assertions.assertThat(((Class)kafkaConfigDoc2.getProperties().get("Class2")).getName())
+                .isEqualTo(GoodClass.class.getName());
     }
+
+    @Test
+    void testGoodType() throws IOException, ClassNotFoundException {
+        String json = "{\n" +
+                "  \"description\" : \"My description\",\n" +
+                "  \"properties\" : {\n" +
+                "    \"aStringValue\" : [ \"stringType\", \"abcdefg\" ],\n" +
+                "    \"aGoodClass\" : [ \"classType\", \"stroom.kafka.impl.TestKafkaConfigSerialiser$GoodClass\" ]\n" +
+                "  },\n" +
+                "  \"kafkaVersion\" : \"0.10.0.1\"\n" +
+                "}";
+
+        LOGGER.info("\n{}", json);
+
+        final Map<String, byte[]> data = Map.of("meta", Bytes.toBytes(json));
+        final KafkaConfigDoc kafkaConfigDoc = serialiser.read(data);
+
+        Assertions.assertThat(kafkaConfigDoc.getProperties().get("aGoodClass"))
+                .isInstanceOf(Class.class);
+        Assertions.assertThat(((Class)kafkaConfigDoc.getProperties().get("aGoodClass")).getName())
+                .isEqualTo(GoodClass.class.getName());
+    }
+
+    @Test
+    void testBadType() throws IOException {
+        String json = "{\n" +
+                "  \"description\" : \"My description\",\n" +
+                "  \"properties\" : {\n" +
+                "    \"aStringValue\" : [ \"stringType\", \"abcdefg\" ],\n" +
+                // want to make sure jackson won't try to instantiate some unknown class
+                "    \"Bad\" : [ \"stroom.kafka.impl.TestKafkaConfigSerialiser.BadClass\", \"some value\" ],\n" +
+                "  },\n" +
+                "  \"kafkaVersion\" : \"0.10.0.1\"\n" +
+                "}";
+
+        final Map<String, byte[]> data = Map.of("meta", Bytes.toBytes(json));
+
+        Assertions.assertThatExceptionOfType(InvalidTypeIdException.class)
+                .isThrownBy(() -> {
+                    serialiser.read(data);
+                });
+    }
+
+    static class BadClass {
+        private static final Logger LOGGER = LoggerFactory.getLogger(BadClass.class);
+
+        BadClass() {
+            LOGGER.info("Ctor called for BadClass");
+        }
+    }
+
+    public static class GoodClass {
+        private static final Logger LOGGER = LoggerFactory.getLogger(GoodClass.class);
+
+        public GoodClass() {
+            LOGGER.info("Ctor called for GoodClass");
+        }
+    }
+
 }

--- a/stroom-core-shared/src/main/java/stroom/kafka/shared/KafkaConfigDoc.java
+++ b/stroom-core-shared/src/main/java/stroom/kafka/shared/KafkaConfigDoc.java
@@ -19,6 +19,7 @@ package stroom.kafka.shared;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import stroom.docstore.shared.Doc;
 
@@ -79,7 +80,17 @@ public class KafkaConfigDoc extends Doc {
         this.kafkaVersion = kafkaVersion;
     }
 
-    @JsonTypeInfo(use=JsonTypeInfo.Id.CLASS, include=JsonTypeInfo.As.WRAPPER_ARRAY)
+    // Kafka expects typed property values so jackson needs to know what
+    // types to de-serialise as using a white list of aliased types
+    @JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.WRAPPER_ARRAY)
+    @JsonSubTypes({
+            @JsonSubTypes.Type(value = Boolean.class, name = "booleanType"),
+            @JsonSubTypes.Type(value = Integer.class, name = "integerType"),
+            @JsonSubTypes.Type(value = Short.class, name = "shortType"),
+            @JsonSubTypes.Type(value = Long.class, name = "longType"),
+            @JsonSubTypes.Type(value = String.class, name = "stringType"),
+            @JsonSubTypes.Type(value = Class.class, name = "classType")
+    })
     public Map<String, Object> getProperties() {
         return properties;
     }


### PR DESCRIPTION
Stops people from trying to deserialise objects of any type.