### PR TITLE
#1494 Scrollbars now have a white background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+* Issue **#1494** : Scrollbars now have a white background unless used in a readonly text area.
+
 * Issue **#1547** : Added pipeline names to processor task screens.
 
 * Issue **#1543** : Prevent import/export of processor filters with id fields

--- a/stroom-app/src/main/resources/ui/css/webkit-scrollbar.css
+++ b/stroom-app/src/main/resources/ui/css/webkit-scrollbar.css
@@ -17,8 +17,7 @@
 /* Scrollbar */
 ::-webkit-scrollbar {
 	width: 12px;
-	/* Use transparent background so it looks better with non-white readonly text areas */
-	background: rgb(0,0,0,0);
+    background: #fff;
 }
 
 ::-webkit-scrollbar:horizontal {
@@ -31,8 +30,7 @@
 
 /* Corner */
 ::-webkit-scrollbar-corner {
-	/* Use transparent background so it looks better with non-white readonly text areas */
-	background: rgb(0,0,0,0);
+    background: #fff;
 }
 
 /* Thumb */
@@ -65,4 +63,15 @@
 ::-webkit-scrollbar-button {
 	width: 0;
 	height: 0;
+}
+
+
+.gwt-TextArea-readonly::-webkit-scrollbar {
+	/* Use transparent background so it looks better with non-white readonly text areas */
+	background: rgb(0,0,0,0);
+}
+
+.gwt-TextArea-readonly::-webkit-scrollbar-corner {
+	/* Use transparent background so it looks better with non-white readonly text areas */
+	background: rgb(0,0,0,0);
 }


### PR DESCRIPTION
Scrollbars now have a white background unless used in a readonly text
area

Fixes #1494