### PR TITLE
#1882 Add capacity restriction to the stream event map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+* Issue **#1883** : Code now deals with missing streams when performing search extraction.
+
 * Issue **#1882** : Added capacity restriction to the stream event map used in search result extraction. The previous version was causing out of memory exceptions.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+* Issue **#1882** : Added capacity restriction to the stream event map used in search result extraction. The previous version was causing out of memory exceptions.
+
 
 ## [v6.1.16] - 2020-09-30
 

--- a/stroom-search/stroom-search-extraction/src/main/java/stroom/search/extraction/Event.java
+++ b/stroom-search/stroom-search-extraction/src/main/java/stroom/search/extraction/Event.java
@@ -48,6 +48,6 @@ class Event implements Comparable<Event> {
 
     @Override
     public String toString() {
-        return String.valueOf(streamId);
+        return streamId + ":" + eventId;
     }
 }

--- a/stroom-search/stroom-search-extraction/src/main/java/stroom/search/extraction/StreamEventMap.java
+++ b/stroom-search/stroom-search-extraction/src/main/java/stroom/search/extraction/StreamEventMap.java
@@ -1,0 +1,68 @@
+package stroom.search.extraction;
+
+import stroom.util.logging.LambdaLogger;
+import stroom.util.logging.LambdaLoggerFactory;
+import stroom.util.shared.HasTerminate;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+class StreamEventMap {
+    private static final LambdaLogger LOGGER = LambdaLoggerFactory.getLogger(StreamEventMap.class);
+
+    private final HasTerminate hasTerminate;
+    private final ConcurrentHashMap<Long, List<Event>> storedDataMap;
+    private final Semaphore available;
+
+    StreamEventMap(final HasTerminate hasTerminate,
+                   final int capacity) {
+        this.hasTerminate = hasTerminate;
+        storedDataMap = new ConcurrentHashMap<>();
+        available = new Semaphore(capacity);
+    }
+
+    void add(final Event event) {
+        try {
+            while (!hasTerminate.isTerminated() &&
+                    !available.tryAcquire(1, TimeUnit.SECONDS)) {
+                LOGGER.debug(() -> "Waiting to add event: " + event);
+            }
+
+            if (!hasTerminate.isTerminated()) {
+                storedDataMap.compute(event.getStreamId(), (k, v) -> {
+                    if (v == null) {
+                        v = new ArrayList<>();
+                    }
+                    v.add(event);
+                    return v;
+                });
+            }
+        } catch (final InterruptedException e) {
+            LOGGER.debug(e::getMessage, e);
+            // Keep interrupting.
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    Map<Long, List<Event>> get() {
+        if (hasTerminate.isTerminated() || Thread.currentThread().isInterrupted()) {
+            return Collections.emptyMap();
+        }
+
+        final Map<Long, List<Event>> map = new HashMap<>();
+        storedDataMap.keySet().forEach(streamId -> {
+            final List<Event> events = storedDataMap.remove(streamId);
+            if (events != null) {
+                available.release(events.size());
+                map.put(streamId, events);
+            }
+        });
+        return map;
+    }
+}

--- a/stroom-search/stroom-search-extraction/src/main/java/stroom/search/extraction/StreamMapCreator.java
+++ b/stroom-search/stroom-search-extraction/src/main/java/stroom/search/extraction/StreamMapCreator.java
@@ -25,9 +25,7 @@ import stroom.streamstore.shared.StreamPermissionException;
 import stroom.util.logging.LambdaLogger;
 import stroom.util.logging.LambdaLoggerFactory;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -68,7 +66,7 @@ class StreamMapCreator {
         return index;
     }
 
-    void addEvent(final Map<Long, List<Event>> storedDataMap, final Val[] storedData) {
+    void addEvent(final StreamEventMap storedDataMap, final Val[] storedData) {
         if (error != null) {
             throw error;
         } else {
@@ -76,13 +74,7 @@ class StreamMapCreator {
             final long longEventId = getLong(storedData, eventIdIndex);
             final Values data = getData(longStreamId, longEventId, storedData);
             final Event event = new Event(longStreamId, longEventId, data);
-            storedDataMap.compute(longStreamId, (k, v) -> {
-                if (v == null) {
-                    v = new ArrayList<>();
-                }
-                v.add(event);
-                return v;
-            });
+            storedDataMap.add(event);
         }
     }
 


### PR DESCRIPTION
Added capacity restriction to the stream event map used in search result
extraction. The previous version was causing out of memory exceptions.