### PR TITLE
Unit test fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -629,8 +629,8 @@ task setupSampleData() {
 
 gradle.buildFinished {
     //if any of the tests failed dump the junit xml to the console
-    if (getPropertyOrDefault('dumpFailedTestXml', 'false') == 'true' && failedTestReportFiles.size > 0) {
-        println "Build has ${failedTestReportFiles.size} failed test classes, dumping JUnit xml output"
+    if (getPropertyOrDefault('dumpFailedTestXml', 'false') == 'true' && failedTestReportFiles.size() > 0) {
+        println "Build has ${failedTestReportFiles.size()} failed test classes, dumping JUnit xml output"
         failedTestReportFiles.each { pair -> 
             def info = pair.first
             def reportFile = pair.second

--- a/stroom-core-server/src/test/java/stroom/proxy/repo/TestStroomZipRepository.java
+++ b/stroom-core-server/src/test/java/stroom/proxy/repo/TestStroomZipRepository.java
@@ -15,6 +15,7 @@ import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.util.Date;
 import java.util.List;
+import java.util.TimeZone;
 import java.util.stream.Stream;
 
 public class TestStroomZipRepository {
@@ -206,6 +207,7 @@ public class TestStroomZipRepository {
 
         String pattern = "yyyy-MM-dd";
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat(pattern);
+        simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
         String nowStr = simpleDateFormat.format(new Date());
         Assert.assertEquals(nowStr, dateDirStr);
     }


### PR DESCRIPTION
* Fixes #2006 by using UTC timezone when executing unit test
* Resolves IDE warning about access to `failedTestReportFiles.size` exceeding access rights, by replacing this with a call to `.size()`