### PR TITLE
Fix solr search issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Issue **#1791** : Fixed Solr connection test response.
 
+* Issue **#2009** : Fixed Solr searches not returning results after the first search completes.
+
 
 ## [v6.1.28] - 2020-11-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Fixed SQL statistics upsert statements for MySQL 5.7.
 
+* Issue **#1793** : Fixed Solr search query creation.
+
+* Issue **#1791** : Fixed Solr connection test response.
+
 
 ## [v6.1.28] - 2020-11-25
 

--- a/build.gradle
+++ b/build.gradle
@@ -629,8 +629,8 @@ task setupSampleData() {
 
 gradle.buildFinished {
     //if any of the tests failed dump the junit xml to the console
-    if (getPropertyOrDefault('dumpFailedTestXml', 'false') == 'true' && failedTestReportFiles.size > 0) {
-        println "Build has ${failedTestReportFiles.size} failed test classes, dumping JUnit xml output"
+    if (getPropertyOrDefault('dumpFailedTestXml', 'false') == 'true' && failedTestReportFiles.size() > 0) {
+        println "Build has ${failedTestReportFiles.size()} failed test classes, dumping JUnit xml output"
         failedTestReportFiles.each { pair -> 
             def info = pair.first
             def reportFile = pair.second

--- a/stroom-core-server/src/test/java/stroom/proxy/repo/TestStroomZipRepository.java
+++ b/stroom-core-server/src/test/java/stroom/proxy/repo/TestStroomZipRepository.java
@@ -15,6 +15,7 @@ import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.util.Date;
 import java.util.List;
+import java.util.TimeZone;
 import java.util.stream.Stream;
 
 public class TestStroomZipRepository {
@@ -206,6 +207,7 @@ public class TestStroomZipRepository {
 
         String pattern = "yyyy-MM-dd";
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat(pattern);
+        simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
         String nowStr = simpleDateFormat.format(new Date());
         Assert.assertEquals(nowStr, dateDirStr);
     }

--- a/stroom-search/stroom-search-extraction/src/main/java/stroom/search/resultsender/ResultSenderImpl.java
+++ b/stroom-search/stroom-search-extraction/src/main/java/stroom/search/resultsender/ResultSenderImpl.java
@@ -120,13 +120,8 @@ class ResultSenderImpl implements ResultSender {
                             LOGGER.trace(() -> "await finished with result " + awaitResult);
                         }
 
-                        // Make sure we don't continue to execute this task if it should have terminated.
-                        if (!taskContext.isTerminated()) {
-                            // Try to send more data.
-                            doSend(coprocessors, consumer, frequency, searchComplete, errors);
-                        } else {
-                            sendingData.complete();
-                        }
+                        // Try to send more data.
+                        doSend(coprocessors, consumer, frequency, searchComplete, errors);
                     }
                 })
                 .exceptionally(t -> {

--- a/stroom-search/stroom-search-solr/src/main/java/stroom/search/solr/search/SolrSearchFactory.java
+++ b/stroom-search/stroom-search-solr/src/main/java/stroom/search/solr/search/SolrSearchFactory.java
@@ -67,8 +67,8 @@ public class SolrSearchFactory {
 
         // Create a map of index fields keyed by name.
         final Map<String, SolrIndexField> indexFieldsMap = index.getFieldsMap();
-        final SearchExpressionQuery query = getQuery(expression, indexFieldsMap, task.getDateTimeLocale(), task.getNow());
-        final String queryString = query.toString();
+        final SearchExpressionQuery searchExpressionQuery = getQuery(expression, indexFieldsMap, task.getDateTimeLocale(), task.getNow());
+        final String queryString = searchExpressionQuery.getQuery().toString();
         final SolrQuery solrQuery = new SolrQuery(queryString);
         solrQuery.setRows(Integer.MAX_VALUE);
 


### PR DESCRIPTION
Issues relating to Solr index search were identified in the 6.1 branch. This PR aims to bring Solr index searching in the 6.1 branch to a functional state.

Cherry-picks fixes relating to the following issues, which to date have only been released in the v7-beta branch:

- Fixes #1793 : Fixed Solr search query creation.
- Fixes #1791 : Fixed Solr connection test response.

Also resolves the following new issue:
- Fixes #2009 : Fixed Solr searches not returning results after the first search completes.

Additionally, a minor fix was made to a unit test in `TestStroomZipRepository`, which was not succeeding on machines using non-UTC time.