### PR TITLE
Elasticsearch index patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Issue **#2214** Allow file permission override for `FileAppender` and `RollingFileAppender`.
 
+* Issue **#2215** Support arrays of strings and objects in Elastic indexing and search.
+
 
 ## [v6.2-beta.1] - 2021-04-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Issue **#2224** : Support indexing properties as JSON objects with Elasticsearch.
 
+* Issue **#2256** : Support searching against Elasticsearch index name patterns.
+
+* Issue **#2257** : Allow Elasticsearch indexing to proceed in the absence of an existing index.
+
 
 ## [v6.2-beta.2] - 2021-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Issue **#2176** : Now avoids NPE and produces a proper error when a pipeline cannot be located when loading reference data.
 
+* Issue **#2224** : Support indexing properties as JSON objects with Elasticsearch.
+
 
 ## [v6.2-beta.2] - 2021-04-21
 
-* Issue **#2179** Extend cron expression syntax. Both `/` (interval) and `-` (range) are now supported.
+* Issue **#2179** : Extend cron expression syntax. Both `/` (interval) and `-` (range) are now supported.
 
-* Issue **#2214** Allow file permission override for `FileAppender` and `RollingFileAppender`.
+* Issue **#2214** : Allow file permission override for `FileAppender` and `RollingFileAppender`.
 
-* Issue **#2215** Support arrays of strings and objects in Elastic indexing and search.
+* Issue **#2215** : Support arrays of strings and objects in Elastic indexing and search.
 
 
 ## [v6.2-beta.1] - 2021-04-02

--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ ext.versions = [
     curator: '4.2.0', // Curator 4 works with ZK 3.4.x in soft compatibility mode, i.e. you must exlude its dep on ZK and explicitly add one for 3.4.x
     dropwizard: '1.3.29', //if you change this version you should check the versions below that need to move in sync with it
     dropwizard_metrics: '4.1.17', //should be kept in step with dropwizard
-    elasticsearch: '7.11.1',
+    elasticsearch: '7.12.0',
     httpcore: '4.4.12', // Transient dependency of Elasticsearch
     gwt: '2.8.2',
     hibernate: '4.3.11.Final', //dropwiz 1.3.14 uses -validator 5.4.3.Final and -core 5.2.18.Final

--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,7 @@ ext.versions = [
     jersey: '2.25.1',
     jetty: '9.4.37.v20210219', //in line with dropwizard 1.3.14
     jooq: '3.11.9',
+    json_path: '2.5.0', // Used to parse JSON search results from Elasticsearch
     logback: '1.2.3', //in line with dropwizard 1.3.14
     lucene: '5.5.3',
     slf4j: '1.7.30', //in line with dropwizard 1.3.14
@@ -193,6 +194,7 @@ ext.libs = [
         jooq_codegen: "org.jooq:jooq-codegen:$versions.jooq",
         jooq_meta: "org.jooq:jooq-meta:$versions.jooq",
         jose4j: "org.bitbucket.b_c:jose4j:0.6.4",
+        json_path: "com.jayway.jsonpath:json-path:$versions.json_path",
         jul_to_slf4j: "org.slf4j:jul-to-slf4j:$versions.slf4j",
         junit: "junit:junit:4.12",
         log4j_over_slf4j: "org.slf4j:log4j-over-slf4j:$versions.slf4j",

--- a/stroom-core-client/src/main/resources/stroom/search/elastic/client/view/ElasticIndexSettingsViewImpl.ui.xml
+++ b/stroom-core-client/src/main/resources/stroom/search/elastic/client/view/ElasticIndexSettingsViewImpl.ui.xml
@@ -36,7 +36,7 @@
                         </g:customCell>
                     </g:row>
                     <g:row>
-                        <g:cell>Index:</g:cell>
+                        <g:cell>Index name or pattern:</g:cell>
                         <g:customCell>
                             <g:TextBox ui:field="indexName" width="400px"/>
                         </g:customCell>

--- a/stroom-core-shared/src/main/java/stroom/search/elastic/shared/ElasticIndexFieldType.java
+++ b/stroom-core-shared/src/main/java/stroom/search/elastic/shared/ElasticIndexFieldType.java
@@ -37,7 +37,7 @@ public enum ElasticIndexFieldType implements HasDisplayValue {
     INTEGER(DataSourceFieldType.INTEGER_FIELD, "Integer", true, false, new String[]{ "integer", "short", "byte" }),
     LONG(DataSourceFieldType.LONG_FIELD, "Long", true, false, new String[]{ "long", "unsigned_long" }),
     FLOAT(DataSourceFieldType.FLOAT_FIELD, "Float", false, true, new String[]{ "float", "half_float", "scaled_float" }),
-    DOUBLE(DataSourceFieldType.DOUBLE_FIELD, "Double", true, true, new String[]{ "double" }),
+    DOUBLE(DataSourceFieldType.DOUBLE_FIELD, "Double", false, true, new String[]{ "double" }),
     DATE(DataSourceFieldType.DATE_FIELD, "Date", false, false, new String[]{ "date" }),
     TEXT(DataSourceFieldType.TEXT_FIELD, "Text", false, false, new String[]{ "text", "keyword", "constant_keyword", "wildcard" });
 

--- a/stroom-core-shared/src/main/java/stroom/search/elastic/shared/ElasticIndexFieldType.java
+++ b/stroom-core-shared/src/main/java/stroom/search/elastic/shared/ElasticIndexFieldType.java
@@ -32,14 +32,14 @@ import java.util.Set;
  * @see "https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html"
  */
 public enum ElasticIndexFieldType implements HasDisplayValue {
-    ID(DataSourceFieldType.ID_FIELD, "Id", true, null),
-    BOOLEAN(DataSourceFieldType.BOOLEAN_FIELD, "Boolean", false, new String[]{ "boolean" }),
-    INTEGER(DataSourceFieldType.INTEGER_FIELD, "Integer", true, new String[]{ "integer", "short", "byte" }),
-    LONG(DataSourceFieldType.LONG_FIELD, "Long", true, new String[]{ "long", "unsigned_long" }),
-    FLOAT(DataSourceFieldType.FLOAT_FIELD, "Float", true, new String[]{ "float", "half_float", "scaled_float" }),
-    DOUBLE(DataSourceFieldType.DOUBLE_FIELD, "Double", true, new String[]{ "double" }),
-    DATE(DataSourceFieldType.DATE_FIELD, "Date", false, new String[]{ "date" }),
-    TEXT(DataSourceFieldType.TEXT_FIELD, "Text", false, new String[]{ "text", "keyword", "constant_keyword", "wildcard" });
+    ID(DataSourceFieldType.ID_FIELD, "Id", true, false, null),
+    BOOLEAN(DataSourceFieldType.BOOLEAN_FIELD, "Boolean", false, false, new String[]{ "boolean" }),
+    INTEGER(DataSourceFieldType.INTEGER_FIELD, "Integer", true, false, new String[]{ "integer", "short", "byte" }),
+    LONG(DataSourceFieldType.LONG_FIELD, "Long", true, false, new String[]{ "long", "unsigned_long" }),
+    FLOAT(DataSourceFieldType.FLOAT_FIELD, "Float", false, true, new String[]{ "float", "half_float", "scaled_float" }),
+    DOUBLE(DataSourceFieldType.DOUBLE_FIELD, "Double", true, true, new String[]{ "double" }),
+    DATE(DataSourceFieldType.DATE_FIELD, "Date", false, false, new String[]{ "date" }),
+    TEXT(DataSourceFieldType.TEXT_FIELD, "Text", false, false, new String[]{ "text", "keyword", "constant_keyword", "wildcard" });
 
     private static Map<String, ElasticIndexFieldType> nativeTypeRegistry = new HashMap<>();
 
@@ -58,6 +58,7 @@ public enum ElasticIndexFieldType implements HasDisplayValue {
     private final DataSourceFieldType dataSourceFieldType;
     private final String displayValue;
     private final boolean numeric;
+    private final boolean decimal;
     private final Set<String> nativeTypes;
     private final List<Condition> supportedConditions;
 
@@ -65,11 +66,13 @@ public enum ElasticIndexFieldType implements HasDisplayValue {
             final DataSourceFieldType dataSourceFieldType,
             final String displayValue,
             final boolean numeric,
+            final boolean decimal,
             final String[] nativeTypes
     ) {
         this.dataSourceFieldType = dataSourceFieldType;
         this.displayValue = displayValue;
         this.numeric = numeric;
+        this.decimal = decimal;
         this.nativeTypes = nativeTypes != null ? new HashSet<>(Arrays.asList(nativeTypes)) : null;
 
         this.supportedConditions = getConditions();
@@ -81,6 +84,10 @@ public enum ElasticIndexFieldType implements HasDisplayValue {
 
     public boolean isNumeric() {
         return numeric;
+    }
+
+    public boolean isDecimal() {
+        return decimal;
     }
 
     public Set<String> getNativeTypes() {

--- a/stroom-core-shared/src/main/java/stroom/search/elastic/shared/ElasticIndexFieldType.java
+++ b/stroom-core-shared/src/main/java/stroom/search/elastic/shared/ElasticIndexFieldType.java
@@ -86,10 +86,6 @@ public enum ElasticIndexFieldType implements HasDisplayValue {
         return numeric;
     }
 
-    public boolean isDecimal() {
-        return decimal;
-    }
-
     public Set<String> getNativeTypes() {
         return nativeTypes;
     }

--- a/stroom-core-shared/src/main/java/stroom/search/elastic/shared/ElasticIndexFieldType.java
+++ b/stroom-core-shared/src/main/java/stroom/search/elastic/shared/ElasticIndexFieldType.java
@@ -32,14 +32,14 @@ import java.util.Set;
  * @see "https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html"
  */
 public enum ElasticIndexFieldType implements HasDisplayValue {
-    ID(DataSourceFieldType.ID_FIELD, "Id", true, false, null),
-    BOOLEAN(DataSourceFieldType.BOOLEAN_FIELD, "Boolean", false, false, new String[]{ "boolean" }),
-    INTEGER(DataSourceFieldType.INTEGER_FIELD, "Integer", true, false, new String[]{ "integer", "short", "byte" }),
-    LONG(DataSourceFieldType.LONG_FIELD, "Long", true, false, new String[]{ "long", "unsigned_long" }),
-    FLOAT(DataSourceFieldType.FLOAT_FIELD, "Float", false, true, new String[]{ "float", "half_float", "scaled_float" }),
-    DOUBLE(DataSourceFieldType.DOUBLE_FIELD, "Double", false, true, new String[]{ "double" }),
-    DATE(DataSourceFieldType.DATE_FIELD, "Date", false, false, new String[]{ "date" }),
-    TEXT(DataSourceFieldType.TEXT_FIELD, "Text", false, false, new String[]{ "text", "keyword", "constant_keyword", "wildcard" });
+    ID(DataSourceFieldType.ID_FIELD, "Id", true, null),
+    BOOLEAN(DataSourceFieldType.BOOLEAN_FIELD, "Boolean", false, new String[]{ "boolean" }),
+    INTEGER(DataSourceFieldType.INTEGER_FIELD, "Integer", true, new String[]{ "integer", "short", "byte" }),
+    LONG(DataSourceFieldType.LONG_FIELD, "Long", true, new String[]{ "long", "unsigned_long" }),
+    FLOAT(DataSourceFieldType.FLOAT_FIELD, "Float", false, new String[]{ "float", "half_float", "scaled_float" }),
+    DOUBLE(DataSourceFieldType.DOUBLE_FIELD, "Double", false, new String[]{ "double" }),
+    DATE(DataSourceFieldType.DATE_FIELD, "Date", false, new String[]{ "date" }),
+    TEXT(DataSourceFieldType.TEXT_FIELD, "Text", false, new String[]{ "text", "keyword", "constant_keyword", "wildcard" });
 
     private static Map<String, ElasticIndexFieldType> nativeTypeRegistry = new HashMap<>();
 
@@ -58,7 +58,6 @@ public enum ElasticIndexFieldType implements HasDisplayValue {
     private final DataSourceFieldType dataSourceFieldType;
     private final String displayValue;
     private final boolean numeric;
-    private final boolean decimal;
     private final Set<String> nativeTypes;
     private final List<Condition> supportedConditions;
 
@@ -66,13 +65,11 @@ public enum ElasticIndexFieldType implements HasDisplayValue {
             final DataSourceFieldType dataSourceFieldType,
             final String displayValue,
             final boolean numeric,
-            final boolean decimal,
             final String[] nativeTypes
     ) {
         this.dataSourceFieldType = dataSourceFieldType;
         this.displayValue = displayValue;
         this.numeric = numeric;
-        this.decimal = decimal;
         this.nativeTypes = nativeTypes != null ? new HashSet<>(Arrays.asList(nativeTypes)) : null;
 
         this.supportedConditions = getConditions();

--- a/stroom-core-shared/src/test/java/TestElasticIndexFieldType.java
+++ b/stroom-core-shared/src/test/java/TestElasticIndexFieldType.java
@@ -29,7 +29,13 @@ public class TestElasticIndexFieldType {
     public void testIsNumeric() {
         Assert.assertTrue(ElasticIndexFieldType.INTEGER.isNumeric());
         Assert.assertTrue(ElasticIndexFieldType.LONG.isNumeric());
-        Assert.assertTrue(ElasticIndexFieldType.FLOAT.isNumeric());
-        Assert.assertTrue(ElasticIndexFieldType.DOUBLE.isNumeric());
+        Assert.assertFalse(ElasticIndexFieldType.FLOAT.isNumeric());
+        Assert.assertFalse(ElasticIndexFieldType.DOUBLE.isNumeric());
+    }
+
+    @Test
+    public void testIsDecimal() {
+        Assert.assertTrue(ElasticIndexFieldType.FLOAT.isDecimal());
+        Assert.assertTrue(ElasticIndexFieldType.DOUBLE.isDecimal());
     }
 }

--- a/stroom-core-shared/src/test/java/TestElasticIndexFieldType.java
+++ b/stroom-core-shared/src/test/java/TestElasticIndexFieldType.java
@@ -32,10 +32,4 @@ public class TestElasticIndexFieldType {
         Assert.assertFalse(ElasticIndexFieldType.FLOAT.isNumeric());
         Assert.assertFalse(ElasticIndexFieldType.DOUBLE.isNumeric());
     }
-
-    @Test
-    public void testIsDecimal() {
-        Assert.assertTrue(ElasticIndexFieldType.FLOAT.isDecimal());
-        Assert.assertTrue(ElasticIndexFieldType.DOUBLE.isDecimal());
-    }
 }

--- a/stroom-pipeline/src/test/java/stroom/pipeline/destination/TestRollingFileDestination.java
+++ b/stroom-pipeline/src/test/java/stroom/pipeline/destination/TestRollingFileDestination.java
@@ -24,6 +24,7 @@ import stroom.util.scheduler.SimpleCron;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 
 public class TestRollingFileDestination {
     @Test
@@ -42,7 +43,8 @@ public class TestRollingFileDestination {
                 "test.log",
                 dir,
                 file,
-                false);
+                false,
+                Collections.emptySet());
 
         Assert.assertFalse(rollingFileDestination.tryFlushAndRoll(false, time));
         Assert.assertFalse(rollingFileDestination.tryFlushAndRoll(false, time + 60000));
@@ -64,7 +66,8 @@ public class TestRollingFileDestination {
                 "test.log",
                 dir,
                 file,
-                false);
+                false,
+                Collections.emptySet());
 
         Assert.assertFalse(rollingFileDestination.tryFlushAndRoll(false, time));
         Assert.assertFalse(rollingFileDestination.tryFlushAndRoll(false, time + 60000));

--- a/stroom-search/stroom-search-elastic/build.gradle
+++ b/stroom-search/stroom-search-elastic/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     compile libs.dropwizard_metrics_annotation
     compile libs.dropwizard_metrics_healthchecks
     compile libs.guava
+    compile libs.json_path
     compile libs.log4j_to_slf4j
     permitUnusedDeclared libs.log4j_to_slf4j
     compile libs.slf4j_api

--- a/stroom-search/stroom-search-elastic/src/main/java/stroom/search/elastic/indexing/ElasticIndexingFilter.java
+++ b/stroom-search/stroom-search-elastic/src/main/java/stroom/search/elastic/indexing/ElasticIndexingFilter.java
@@ -403,8 +403,10 @@ class ElasticIndexingFilter extends AbstractXMLFilter {
 
             if (elasticFieldType.isNumeric()) {
                 val = Long.parseLong(value);
-            } else if (elasticFieldType.isDecimal()) {
+            } else if (elasticFieldType.equals(ElasticIndexFieldType.FLOAT)) {
                 val = Float.parseFloat(value);
+            } else if (elasticFieldType.equals(ElasticIndexFieldType.DOUBLE)) {
+                val = Double.parseDouble(value);
             } else if (ElasticIndexFieldType.DATE.equals(elasticFieldType)) {
                 try {
                     val = DateUtil.parseUnknownString(value);

--- a/stroom-search/stroom-search-elastic/src/main/java/stroom/search/elastic/indexing/ElasticIndexingFilter.java
+++ b/stroom-search/stroom-search-elastic/src/main/java/stroom/search/elastic/indexing/ElasticIndexingFilter.java
@@ -62,6 +62,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Takes index XML and sends documents to Elasticsearch for indexing
@@ -356,13 +357,11 @@ class ElasticIndexingFilter extends AbstractXMLFilter {
                         BulkRequest bulkRequest = new BulkRequest();
 
                         // For each document, create an indexing request and append to the bulk request
-                        documents.forEach(document -> {
-                            final IndexRequest indexRequest = new IndexRequest(indexName)
-                                .opType(OpType.CREATE)
-                                .source(document);
-
-                            bulkRequest.add(indexRequest);
-                        });
+                        bulkRequest.add(
+                                documents.stream().map(document -> new IndexRequest(indexName)
+                                        .opType(OpType.CREATE)
+                                        .source(document)).collect(Collectors.toList())
+                        );
 
                         if (refreshAfterEachBatch) {
                             // Refresh upon completion of the batch index request

--- a/stroom-search/stroom-search-elastic/src/main/java/stroom/search/elastic/indexing/ElasticIndexingFilter.java
+++ b/stroom-search/stroom-search-elastic/src/main/java/stroom/search/elastic/indexing/ElasticIndexingFilter.java
@@ -399,10 +399,13 @@ class ElasticIndexingFilter extends AbstractXMLFilter {
     private void addFieldToDocument(final ElasticIndexField indexField, final String value) {
         try {
             Object val = null;
+            final ElasticIndexFieldType elasticFieldType = indexField.getFieldUse();
 
-            if (indexField.getFieldUse().isNumeric()) {
+            if (elasticFieldType.isNumeric()) {
                 val = Long.parseLong(value);
-            } else if (ElasticIndexFieldType.DATE.equals(indexField.getFieldUse())) {
+            } else if (elasticFieldType.isDecimal()) {
+                val = Float.parseFloat(value);
+            } else if (ElasticIndexFieldType.DATE.equals(elasticFieldType)) {
                 try {
                     val = DateUtil.parseUnknownString(value);
                 } catch (final Exception e) {

--- a/stroom-search/stroom-search-elastic/src/main/java/stroom/search/elastic/indexing/ElasticIndexingFilter.java
+++ b/stroom-search/stroom-search-elastic/src/main/java/stroom/search/elastic/indexing/ElasticIndexingFilter.java
@@ -275,24 +275,28 @@ class ElasticIndexingFilter extends AbstractXMLFilter {
             } else if (currentArrayString != null) {
                 // An array string has ended
                 currentArrayString = null;
-            } else if (currentObjectArray != null && currentObjectArray.size() > 0) {
-                // We're at the end of an object array, so commit it to the document
-                addFieldToDocument(currentPropertyName, currentObjectArray);
-                currentStringArray = null;
-                currentObjectArray = null;
-                currentObject = null;
-            } else if (currentStringArray != null && currentStringArray.size() > 0) {
-                // End of a string array
-                addFieldToDocument(currentPropertyName, currentStringArray);
-                currentStringArray = null;
-                currentObjectArray = null;
-                currentObject = null;
-            } else if (currentObject != null && currentObject.size() > 0) {
-                // End of plain object
-                addFieldToDocument(currentPropertyName, currentObject);
-                currentStringArray = null;
-                currentObjectArray = null;
-                currentObject = null;
+            } else {
+                if (currentObjectArray != null) {
+                    // We're at the end of an object array, so commit it to the document
+                    if (currentObjectArray.size() > 0) {
+                        addFieldToDocument(currentPropertyName, currentObjectArray);
+                    }
+                    currentObjectArray = null;
+                }
+                if (currentStringArray != null) {
+                    // End of a string array
+                    if (currentStringArray.size() > 0) {
+                        addFieldToDocument(currentPropertyName, currentStringArray);
+                    }
+                    currentStringArray = null;
+                }
+                if (currentObject != null) {
+                    // End of plain object
+                    if (currentObject.size() > 0) {
+                        addFieldToDocument(currentPropertyName, currentObject);
+                    }
+                    currentObject = null;
+                }
             }
         } else if (RECORD_ELEMENT_NAME.equals(localName)) {
             processDocument();

--- a/stroom-search/stroom-search-elastic/src/main/java/stroom/search/elastic/indexing/ElasticIndexingFilter.java
+++ b/stroom-search/stroom-search-elastic/src/main/java/stroom/search/elastic/indexing/ElasticIndexingFilter.java
@@ -221,7 +221,6 @@ class ElasticIndexingFilter extends AbstractXMLFilter {
 
                     currentStringArray = new ArrayList<>();
                     currentObjectArray = new ArrayList<>();
-                    currentArrayObject = new HashMap<>();
                     currentObject = new HashMap<>();
                     currentPropertyName = name;
                 } else {

--- a/stroom-search/stroom-search-elastic/src/main/java/stroom/search/elastic/indexing/ElasticIndexingFilter.java
+++ b/stroom-search/stroom-search-elastic/src/main/java/stroom/search/elastic/indexing/ElasticIndexingFilter.java
@@ -213,12 +213,15 @@ class ElasticIndexingFilter extends AbstractXMLFilter {
                 if (value == null) {
                     // Node with a name and no value. Treat this as the start of an array.
                     // Could be either a string or object array.
-                    if (currentStringArray != null || currentObjectArray != null) {
+                    if (currentStringArray != null && currentStringArray.size() > 0 ||
+                        currentObjectArray != null && currentObjectArray.size() > 0
+                    ) {
                         throw new SAXException("Cannot nest an array within another array");
                     }
 
                     currentStringArray = new ArrayList<>();
                     currentObjectArray = new ArrayList<>();
+                    currentArrayObject = new HashMap<>();
                     currentObject = new HashMap<>();
                     currentPropertyName = name;
                 } else {
@@ -282,6 +285,7 @@ class ElasticIndexingFilter extends AbstractXMLFilter {
                         addFieldToDocument(currentPropertyName, currentObjectArray);
                     }
                     currentObjectArray = null;
+                    currentArrayObject = null;
                 }
                 if (currentStringArray != null) {
                     // End of a string array
@@ -302,11 +306,12 @@ class ElasticIndexingFilter extends AbstractXMLFilter {
             processDocument();
             document = null;
             currentStringArray = null;
+            currentArrayString = null;
             currentObjectArray = null;
             currentArrayObject = null;
-            isBuildingArrayObject = false;
-            currentArrayString = null;
             currentObject = null;
+            isBuildingArrayObject = false;
+            isBuildingObject = false;
 
             // Reset the count of how many fields we have indexed for the
             // current event.

--- a/stroom-search/stroom-search-elastic/src/main/java/stroom/search/elastic/search/ElasticSearchTaskHandler.java
+++ b/stroom-search/stroom-search-elastic/src/main/java/stroom/search/elastic/search/ElasticSearchTaskHandler.java
@@ -39,6 +39,9 @@ import stroom.util.shared.VoidResult;
 import stroom.util.spring.StroomScope;
 import stroom.util.task.TaskWrapper;
 
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.JsonPathException;
 import org.elasticsearch.action.search.ClearScrollRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
@@ -196,29 +199,35 @@ public class ElasticSearchTaskHandler {
             for (final SearchHit searchHit : searchHits) {
                 tracker.incrementHitCount();
 
+                final DocumentContext jsonSearchHit = JsonPath.parse(searchHit.getSourceAsString());
                 Val[] values = null;
+
                 for (int i = 0; i < fieldNames.length; i++) {
                     final String fieldName = fieldNames[i];
-                    final Object value = searchHit.getSourceAsMap().get(fieldName);
 
-                    if (value != null) {
-                        if (values == null) {
-                            values = new Val[fieldNames.length];
-                        }
+                    try {
+                        final Object value = jsonSearchHit.read(fieldName);
+                        if (value != null) {
+                            if (values == null) {
+                                values = new Val[fieldNames.length];
+                            }
 
-                        if (value instanceof Long) {
-                            values[i] = ValLong.create((Long) value);
-                        } else if (value instanceof Integer) {
-                            values[i] = ValInteger.create((Integer) value);
-                        } else if (value instanceof Double) {
-                            values[i] = ValDouble.create((Double) value);
-                        } else if (value instanceof Float) {
-                            values[i] = ValDouble.create((Float) value);
-                        } else if (value instanceof Boolean) {
-                            values[i] = ValBoolean.create((Boolean) value);
-                        } else {
-                            values[i] = ValString.create(value.toString());
+                            if (value instanceof Long) {
+                                values[i] = ValLong.create((Long) value);
+                            } else if (value instanceof Integer) {
+                                values[i] = ValInteger.create((Integer) value);
+                            } else if (value instanceof Double) {
+                                values[i] = ValDouble.create((Double) value);
+                            } else if (value instanceof Float) {
+                                values[i] = ValDouble.create((Float) value);
+                            } else if (value instanceof Boolean) {
+                                values[i] = ValBoolean.create((Boolean) value);
+                            } else {
+                                values[i] = ValString.create(value.toString());
+                            }
                         }
+                    } catch (JsonPathException e) {
+                        // Field not found. Ignore, as it was probably a system field
                     }
                 }
 

--- a/stroom-search/stroom-search-elastic/src/main/java/stroom/search/elastic/search/SearchExpressionQueryBuilder.java
+++ b/stroom-search/stroom-search-elastic/src/main/java/stroom/search/elastic/search/SearchExpressionQueryBuilder.java
@@ -36,7 +36,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Convert our query objects to an Elasticsearch Query DSL query.
@@ -148,140 +152,17 @@ public class SearchExpressionQueryBuilder {
         }
 
         // Create a query based on the field type and condition.
+        final ElasticIndexFieldType elasticFieldType = indexField.getFieldUse();
         if (indexField.getFieldUse().isNumeric()) {
-            long valueAsNum = getNumber(fieldName, value);
-            switch (condition) {
-                case EQUALS:
-                    return QueryBuilders
-                            .termQuery(fieldName, valueAsNum);
-                case CONTAINS:
-                case IN:
-                    return QueryBuilders
-                            .termsQuery(fieldName, tokenizeExpression(value));
-                case GREATER_THAN:
-                    return QueryBuilders
-                            .rangeQuery(fieldName)
-                            .gt(valueAsNum);
-                case GREATER_THAN_OR_EQUAL_TO:
-                    return QueryBuilders
-                            .rangeQuery(fieldName)
-                            .gte(valueAsNum);
-                case LESS_THAN:
-                    return QueryBuilders
-                            .rangeQuery(fieldName)
-                            .lt(valueAsNum);
-                case LESS_THAN_OR_EQUAL_TO:
-                    return QueryBuilders
-                            .rangeQuery(fieldName)
-                            .lte(valueAsNum);
-                case BETWEEN:
-                    final Long[] between = getNumbers(fieldName, value);
-                    if (between.length != 2) {
-                        throw new IllegalArgumentException("Two numbers needed for between query; " + between.length + " provided");
-                    }
-                    if (between[0] >= between[1]) {
-                        throw new IllegalArgumentException("From number must be lower than to number");
-                    }
-                    return QueryBuilders
-                            .rangeQuery(fieldName)
-                            .gte(between[0])
-                            .lte(between[1]);
-                case IN_DICTIONARY:
-                    return buildDictionaryQuery(fieldName, docRef, indexField);
-                default:
-                    throw new RuntimeException("Unexpected condition '" + condition.getDisplayValue() + "' for "
-                            + indexField.getFieldUse().getDisplayValue() + " field type");
-            }
-        } else if (indexField.getFieldUse().isDecimal()) {
-            float valueAsFloat = getDecimal(fieldName, value);
-            switch (condition) {
-                case EQUALS:
-                    return QueryBuilders
-                            .termQuery(fieldName, valueAsFloat);
-                case CONTAINS:
-                case IN:
-                    return QueryBuilders
-                            .termsQuery(fieldName, tokenizeExpression(value));
-                case GREATER_THAN:
-                    return QueryBuilders
-                            .rangeQuery(fieldName)
-                            .gt(valueAsFloat);
-                case GREATER_THAN_OR_EQUAL_TO:
-                    return QueryBuilders
-                            .rangeQuery(fieldName)
-                            .gte(valueAsFloat);
-                case LESS_THAN:
-                    return QueryBuilders
-                            .rangeQuery(fieldName)
-                            .lt(valueAsFloat);
-                case LESS_THAN_OR_EQUAL_TO:
-                    return QueryBuilders
-                            .rangeQuery(fieldName)
-                            .lte(valueAsFloat);
-                case BETWEEN:
-                    final Long[] between = getNumbers(fieldName, value);
-                    if (between.length != 2) {
-                        throw new IllegalArgumentException("Two numbers needed for between query; " + between.length + " provided");
-                    }
-                    if (between[0] >= between[1]) {
-                        throw new IllegalArgumentException("From number must be lower than to number");
-                    }
-                    return QueryBuilders
-                            .rangeQuery(fieldName)
-                            .gte(between[0])
-                            .lte(between[1]);
-                case IN_DICTIONARY:
-                    return buildDictionaryQuery(fieldName, docRef, indexField);
-                default:
-                    throw new RuntimeException("Unexpected condition '" + condition.getDisplayValue() + "' for "
-                            + indexField.getFieldUse().getDisplayValue() + " field type");
-            }
-        } else if (ElasticIndexFieldType.DATE.equals(indexField.getFieldUse())) {
-            final Long valueAsDate = getDate(fieldName, value);
-            switch (condition) {
-                case EQUALS:
-                    return QueryBuilders
-                            .termQuery(fieldName, valueAsDate);
-                case CONTAINS:
-                case IN:
-                    final long[] dates = getDates(fieldName, value);
-                    return QueryBuilders
-                            .termsQuery(fieldName, dates);
-                case GREATER_THAN:
-                    return QueryBuilders
-                            .rangeQuery(fieldName)
-                            .gt(valueAsDate);
-                case GREATER_THAN_OR_EQUAL_TO:
-                    return QueryBuilders
-                            .rangeQuery(fieldName)
-                            .gte(valueAsDate);
-                case LESS_THAN:
-                    return QueryBuilders
-                            .rangeQuery(fieldName)
-                            .lt(valueAsDate);
-                case LESS_THAN_OR_EQUAL_TO:
-                    return QueryBuilders
-                            .rangeQuery(fieldName)
-                            .lte(valueAsDate);
-                case BETWEEN:
-                    final long[] between = getDates(fieldName, value);
-                    if (between.length != 2) {
-                        throw new IllegalArgumentException("Two dates needed for between query; " + between.length + " provided");
-                    }
-                    if (between[0] >= between[1]) {
-                        throw new IllegalArgumentException("From date must occur before to date");
-                    }
-                    return QueryBuilders
-                            .rangeQuery(fieldName)
-                            .gte(between[0])
-                            .lte(between[1]);
-                case IN_DICTIONARY:
-                    return buildDictionaryQuery(fieldName, docRef, indexField);
-                default:
-                    throw new RuntimeException("Unexpected condition '" + condition.getDisplayValue() + "' for "
-                            + indexField.getFieldUse().getDisplayValue() + " field type");
-            }
+            return buildNumericQuery(condition, indexField, fieldName, value, this::getNumber, docRef);
+        } else if (elasticFieldType.equals(ElasticIndexFieldType.FLOAT)) {
+            return buildNumericQuery(condition, indexField, fieldName, value, this::getFloat, docRef);
+        } else if (elasticFieldType.equals(ElasticIndexFieldType.DOUBLE)) {
+            return buildNumericQuery(condition, indexField, fieldName, value, this::getDouble, docRef);
+        } else if (elasticFieldType.equals(ElasticIndexFieldType.DATE)) {
+            return buildNumericQuery(condition, indexField, fieldName, value, this::getDate, docRef);
         } else {
+            // A string-based term
             switch (condition) {
                 case EQUALS:
                     return QueryBuilders
@@ -294,12 +175,9 @@ public class SearchExpressionQueryBuilder {
 
                     // All terms must match
                     BoolQueryBuilder mustQuery = QueryBuilders.boolQuery();
-                    String[] terms = tokenizeExpression(value);
-                    for (final String term : terms) {
-                        mustQuery.must(
-                            QueryBuilders.termQuery(fieldName, term)
-                        );
-                    }
+                    tokenizeExpression(value).forEach(term -> {
+                        mustQuery.must(QueryBuilders.termQuery(fieldName, term));
+                    });
                     return mustQuery;
                 case IN:
                     // One or more terms must match
@@ -317,51 +195,81 @@ public class SearchExpressionQueryBuilder {
         }
     }
 
+    private <T extends Number> QueryBuilder buildNumericQuery(
+            final ExpressionTerm.Condition condition, final ElasticIndexField indexField, final String fieldName,
+            final String fieldValue, BiFunction<String, String, T> valueParser, final DocRef docRef
+    ) {
+        T numericValue;
+        List<T> numericValues;
+
+        switch (condition) {
+            case EQUALS:
+                numericValue = valueParser.apply(fieldName, fieldValue);
+                return QueryBuilders
+                        .termQuery(fieldName, numericValue);
+            case CONTAINS:
+            case IN:
+                numericValues = tokenizeExpression(fieldValue)
+                        .map(val -> valueParser.apply(fieldName, val))
+                        .collect(Collectors.toList());
+                return QueryBuilders
+                        .termsQuery(fieldName, numericValues);
+            case GREATER_THAN:
+                numericValue = valueParser.apply(fieldName, fieldValue);
+                return QueryBuilders
+                        .rangeQuery(fieldName)
+                        .gt(numericValue);
+            case GREATER_THAN_OR_EQUAL_TO:
+                numericValue = valueParser.apply(fieldName, fieldValue);
+                return QueryBuilders
+                        .rangeQuery(fieldName)
+                        .gte(numericValue);
+            case LESS_THAN:
+                numericValue = valueParser.apply(fieldName, fieldValue);
+                return QueryBuilders
+                        .rangeQuery(fieldName)
+                        .lt(numericValue);
+            case LESS_THAN_OR_EQUAL_TO:
+                numericValue = valueParser.apply(fieldName, fieldValue);
+                return QueryBuilders
+                        .rangeQuery(fieldName)
+                        .lte(numericValue);
+            case BETWEEN:
+                numericValues = tokenizeExpression(fieldValue)
+                        .map(val -> valueParser.apply(fieldName, val))
+                        .collect(Collectors.toList());
+                if (numericValues.size() != 2) {
+                    throw new IllegalArgumentException("Two values needed for between query; " + numericValues.size() + " provided");
+                }
+                return QueryBuilders
+                        .rangeQuery(fieldName)
+                        .gte(numericValues.get(0))
+                        .lte(numericValues.get(1));
+            case IN_DICTIONARY:
+                return buildDictionaryQuery(fieldName, docRef, indexField);
+            default:
+                throw new RuntimeException("Unexpected condition '" + condition.getDisplayValue() + "' for " +
+                        indexField.getFieldUse().getDisplayValue() + " field type");
+        }
+    }
+
     /**
      * Split an expression into is component terms. Useful for extracting terms for use with "in" or "contains" conditions
      * @param expression - Example: "1,2, 3"
-     * @return - Array of terms. Example: [ "1", "2", "3" ]
+     * @return - Stream of terms. Example: [ "1", "2", "3" ]
      */
-    private String[] tokenizeExpression(final String expression) {
+    private Stream<String> tokenizeExpression(final String expression) {
         if (expression != null) {
             return Arrays.stream(expression.split(DELIMITER))
                 .map(String::trim)
-                .filter(token -> !token.isEmpty())
-                .toArray(String[]::new);
+                .filter(token -> !token.isEmpty());
         }
         else {
-            return new String[]{ };
+            return Stream.empty();
         }
     }
 
-    /**
-     * Tokenize an expression and convert each item to a numeric `long`
-     */
-    private Long[] getNumbers(final String fieldName, final String expr) {
-        return Arrays.stream(tokenizeExpression(expr))
-            .map(token -> getNumber(fieldName, token))
-            .toArray(Long[]::new);
-    }
-
-    /**
-     * Tokenize an expression and convert each item to a numeric `float`
-     */
-    private Float[] getDecimals(final String fieldName, final String expr) {
-        return Arrays.stream(tokenizeExpression(expr))
-                .map(token -> getDecimal(fieldName, token))
-                .toArray(Float[]::new);
-    }
-
-    /**
-     * Tokenize an expression and convert each item to a date `long`
-     */
-    private long[] getDates(final String fieldName, final String expr) {
-        return Arrays.stream(tokenizeExpression(expr))
-            .mapToLong(token -> getDate(fieldName, token))
-            .toArray();
-    }
-
-    private long getDate(final String fieldName, final String value) {
+    private Long getDate(final String fieldName, final String value) {
         try {
             // Empty optional will be caught below
             return DateExpressionParser.parse(value, timeZoneId, nowEpochMilli).get().toInstant().toEpochMilli();
@@ -371,7 +279,7 @@ public class SearchExpressionQueryBuilder {
         }
     }
 
-    private long getNumber(final String fieldName, final String value) {
+    private Long getNumber(final String fieldName, final String value) {
         try {
             return Long.parseLong(value);
         } catch (final NumberFormatException e) {
@@ -381,12 +289,22 @@ public class SearchExpressionQueryBuilder {
         }
     }
 
-    private float getDecimal(final String fieldName, final String value) {
+    private Float getFloat(final String fieldName, final String value) {
         try {
             return Float.parseFloat(value);
         } catch (final NumberFormatException e) {
             throw new NumberFormatException(
-                    "Expected a decimal value for field \"" + fieldName + "\" but was given string \"" + value + "\""
+                    "Expected a decimal (float) value for field \"" + fieldName + "\" but was given string \"" + value + "\""
+            );
+        }
+    }
+
+    private Double getDouble(final String fieldName, final String value) {
+        try {
+            return Double.parseDouble(value);
+        } catch (final NumberFormatException e) {
+            throw new NumberFormatException(
+                    "Expected a decimal (double) value for field \"" + fieldName + "\" but was given string \"" + value + "\""
             );
         }
     }
@@ -403,35 +321,27 @@ public class SearchExpressionQueryBuilder {
 
         for (final String line : lines) {
             BoolQueryBuilder mustQuery = QueryBuilders.boolQuery();
+            final ElasticIndexFieldType elasticFieldType = indexField.getFieldUse();
 
-            if (indexField.getFieldUse().isNumeric()) {
-                final Long[] numbers = getNumbers(fieldName, line);
-                for (final Long number : numbers) {
-                    mustQuery.must(
-                        QueryBuilders.termQuery(fieldName, number)
-                    );
-                }
-            } else if (indexField.getFieldUse().isDecimal()) {
-                final Float[] decimals = getDecimals(fieldName, line);
-                for (final Float decimal : decimals) {
-                    mustQuery.must(
-                            QueryBuilders.termQuery(fieldName, decimal)
-                    );
-                }
+            if (elasticFieldType.isNumeric()) {
+                tokenizeExpression(line)
+                        .map(val -> getNumber(fieldName, val))
+                        .forEach(number -> mustQuery.must(QueryBuilders.termQuery(fieldName, number)));
+            } else if (elasticFieldType.equals(ElasticIndexFieldType.FLOAT)) {
+                tokenizeExpression(line)
+                        .map(val -> getFloat(fieldName, val))
+                        .forEach(number -> mustQuery.must(QueryBuilders.termQuery(fieldName, number)));
+            } else if (elasticFieldType.equals(ElasticIndexFieldType.DOUBLE)) {
+                tokenizeExpression(line)
+                        .map(val -> getDouble(fieldName, val))
+                        .forEach(number -> mustQuery.must(QueryBuilders.termQuery(fieldName, number)));
             } else if (ElasticIndexFieldType.DATE.equals(indexField.getFieldUse())) {
-                final long[] dates = getDates(fieldName, line);
-                for (final Long date : dates) {
-                    mustQuery.must(
-                        QueryBuilders.termQuery(fieldName, date)
-                    );
-                }
+                tokenizeExpression(line)
+                        .map(val -> getDate(fieldName, val))
+                        .forEach(number -> mustQuery.must(QueryBuilders.termQuery(fieldName, number)));
             } else {
-                final String[] terms = tokenizeExpression(line);
-                for (final String term : terms) {
-                    mustQuery.must(
-                        QueryBuilders.termQuery(fieldName, term)
-                    );
-                }
+                tokenizeExpression(line)
+                        .forEach(term -> mustQuery.must(QueryBuilders.termQuery(fieldName, term)));
             }
 
             builder.should(mustQuery);


### PR DESCRIPTION
This PR enables users to:

1. Use Elasticsearch index templates or data streams, whereby an index is created automatically based on a matching template. Previously the index had to exist within the cluster, else Stroom would throw an error.
2. Specify an index name pattern, or list of indices, in an `Elasticsearch Index` entity. Effectively, this enables a Stroom search to target multiple Elasticsearch indices at once.

Closes #2256 and #2257.