### PR TITLE
Close dialogs on Escape/Enter keypress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+* Issue **#2278** : Close a dialog box on keypress. `Escape` = Close, `Ctrl+Enter` = OK.
+
 * Fix problem with DynamicAssetsBundle throwing an exception when run from the fat jar.
 
 * Issue **#2295** : Improved appearance, readability and usability of UI elements, especially in dark mode. 

--- a/stroom-core-client-widget/src/main/java/stroom/widget/popup/client/view/AbstractPopupPanel.java
+++ b/stroom-core-client-widget/src/main/java/stroom/widget/popup/client/view/AbstractPopupPanel.java
@@ -17,19 +17,59 @@
 package stroom.widget.popup.client.view;
 
 import stroom.data.grid.client.Glass;
+import stroom.widget.popup.client.presenter.PopupView.PopupType;
 
+import com.google.gwt.dom.client.NativeEvent;
+import com.google.gwt.event.dom.client.KeyCodes;
+import com.google.gwt.user.client.Event;
+import com.google.gwt.user.client.Event.NativePreviewEvent;
 import com.google.gwt.user.client.ui.PopupPanel;
 
 public abstract class AbstractPopupPanel extends PopupPanel implements Popup {
+    private final PopupType popupType;
     private final Glass dragGlass = new Glass(
             "popupPanel-dragGlass",
             "popupPanel-dragGlassVisible");
 
-    public AbstractPopupPanel(final boolean autoHide, final boolean modal) {
+    public AbstractPopupPanel(final boolean autoHide, final boolean modal, final PopupType popupType) {
         super(autoHide, modal);
+        this.popupType = popupType;
     }
 
     public Glass getDragGlass() {
         return dragGlass;
     }
+
+    /**
+     * Notify the dialog when either the Enter or Escape key is pressed.
+     * For dialogs with a close button, the Escape will cause them to close. The Enter key will close the dialog,
+     * with a `true` result. The exception to this is where a keyboard modifier (like Shift) is held. This allows
+     * the user to press Enter within a dialog without dismissing it, such as when typing in a multiline text field.
+     * @param event
+     */
+    @Override
+    protected void onPreviewNativeEvent(final NativePreviewEvent event) {
+        super.onPreviewNativeEvent(event);
+
+        if (event.getTypeInt() == Event.ONKEYDOWN) {
+            final NativeEvent nativeEvent = event.getNativeEvent();
+
+            switch (nativeEvent.getKeyCode()) {
+                case KeyCodes.KEY_ESCAPE:
+                    onEscapeKeyPressed();
+                    break;
+                case KeyCodes.KEY_ENTER:
+                    if (!(nativeEvent.getAltKey() || nativeEvent.getCtrlKey() || nativeEvent.getShiftKey())) {
+                        onEnterKeyPressed();
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    protected void onEscapeKeyPressed() { }
+
+    protected void onEnterKeyPressed() { }
 }

--- a/stroom-core-client-widget/src/main/java/stroom/widget/popup/client/view/AbstractPopupPanel.java
+++ b/stroom-core-client-widget/src/main/java/stroom/widget/popup/client/view/AbstractPopupPanel.java
@@ -42,10 +42,8 @@ public abstract class AbstractPopupPanel extends PopupPanel implements Popup {
 
     /**
      * Notify the dialog when either the Enter or Escape key is pressed.
-     * For dialogs with a close button, the Escape will cause them to close. The Enter key will close the dialog,
-     * with a `true` result. The exception to this is where a keyboard modifier (like Shift) is held. This allows
-     * the user to press Enter within a dialog without dismissing it, such as when typing in a multiline text field.
-     * @param event
+     * For dialogs with a close button, the Escape will cause them to close.
+     * The combination Ctrl+Enter key will close the dialog, with a `true` result.
      */
     @Override
     protected void onPreviewNativeEvent(final NativePreviewEvent event) {
@@ -59,7 +57,8 @@ public abstract class AbstractPopupPanel extends PopupPanel implements Popup {
                     onEscapeKeyPressed();
                     break;
                 case KeyCodes.KEY_ENTER:
-                    if (!(nativeEvent.getAltKey() || nativeEvent.getCtrlKey() || nativeEvent.getShiftKey())) {
+                    // Only close the dialog if the Ctrl modifier is pressed
+                    if (nativeEvent.getCtrlKey()) {
                         onEnterKeyPressed();
                     }
                     break;

--- a/stroom-core-client-widget/src/main/java/stroom/widget/popup/client/view/Dialog.java
+++ b/stroom-core-client-widget/src/main/java/stroom/widget/popup/client/view/Dialog.java
@@ -17,6 +17,7 @@
 package stroom.widget.popup.client.view;
 
 import stroom.widget.popup.client.presenter.PopupUiHandlers;
+import stroom.widget.popup.client.presenter.PopupView.PopupType;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Document;
@@ -60,8 +61,8 @@ public class Dialog extends AbstractPopupPanel {
      * Creates an empty dialog box. It should not be shown until its child
      * widget has been added using {@link #add(Widget)}.
      */
-    public Dialog(final PopupUiHandlers popupUiHandlers) {
-        this(popupUiHandlers, false);
+    public Dialog(final PopupUiHandlers popupUiHandlers, final PopupType popupType) {
+        this(popupUiHandlers, false, popupType);
     }
 
     /**
@@ -72,8 +73,8 @@ public class Dialog extends AbstractPopupPanel {
      * @param autoHide <code>true</code> if the dialog should be automatically hidden
      *                 when the user clicks outside of it
      */
-    public Dialog(final PopupUiHandlers popupUiHandlers, final boolean autoHide) {
-        this(popupUiHandlers, autoHide, true);
+    public Dialog(final PopupUiHandlers popupUiHandlers, final boolean autoHide, final PopupType popupType) {
+        this(popupUiHandlers, autoHide, true, popupType);
     }
 
     /**
@@ -86,8 +87,9 @@ public class Dialog extends AbstractPopupPanel {
      * @param modal    <code>true</code> if keyboard and mouse events for widgets not
      *                 contained by the dialog should be ignored
      */
-    public Dialog(final PopupUiHandlers popupUiHandlers, final boolean autoHide, final boolean modal) {
-        super(autoHide, modal);
+    public Dialog(final PopupUiHandlers popupUiHandlers, final boolean autoHide, final boolean modal,
+                  final PopupType popupType) {
+        super(autoHide, modal, popupType);
         this.popupUiHandlers = popupUiHandlers;
 
         setStyleName("dialog-popup");
@@ -144,6 +146,16 @@ public class Dialog extends AbstractPopupPanel {
     @Override
     public void hide(final boolean autoClosed) {
         popupUiHandlers.onHideRequest(autoClosed, false);
+    }
+
+    @Override
+    protected void onEscapeKeyPressed() {
+        hide(false);
+    }
+
+    @Override
+    protected void onEnterKeyPressed() {
+        popupUiHandlers.onHideRequest(false, true);
     }
 
     @Override

--- a/stroom-core-client-widget/src/main/java/stroom/widget/popup/client/view/PopupSupportImpl.java
+++ b/stroom-core-client-widget/src/main/java/stroom/widget/popup/client/view/PopupSupportImpl.java
@@ -298,25 +298,25 @@ public class PopupSupportImpl implements PopupSupport {
                     popup.setContent(view.asWidget());
                     break;
                 case DIALOG:
-                    popup = new ResizableDialog(popupUiHandlers, popupSize);
+                    popup = new ResizableDialog(popupUiHandlers, popupSize, popupType);
                     popup.setContent(view.asWidget());
                     break;
                 case CLOSE_DIALOG:
-                    popup = new ResizableDialog(popupUiHandlers, popupSize);
+                    popup = new ResizableDialog(popupUiHandlers, popupSize, popupType);
                     final ResizableCloseContent closeContent = new ResizableCloseContent(popupUiHandlers);
                     controls = closeContent;
                     closeContent.setContent(view.asWidget());
                     popup.setContent(closeContent);
                     break;
                 case OK_CANCEL_DIALOG:
-                    popup = new ResizableDialog(popupUiHandlers, popupSize);
+                    popup = new ResizableDialog(popupUiHandlers, popupSize, popupType);
                     final ResizableOkCancelContent okCancelContent = new ResizableOkCancelContent(popupUiHandlers);
                     controls = okCancelContent;
                     okCancelContent.setContent(view.asWidget());
                     popup.setContent(okCancelContent);
                     break;
                 case ACCEPT_REJECT_DIALOG:
-                    popup = new ResizableDialog(popupUiHandlers, popupSize);
+                    popup = new ResizableDialog(popupUiHandlers, popupSize, popupType);
                     final ResizableAcceptRejectContent acceptRejectContent = new ResizableAcceptRejectContent(
                             popupUiHandlers);
                     controls = acceptRejectContent;
@@ -331,25 +331,25 @@ public class PopupSupportImpl implements PopupSupport {
                     popup.setContent(view.asWidget());
                     break;
                 case DIALOG:
-                    popup = new Dialog(popupUiHandlers);
+                    popup = new Dialog(popupUiHandlers, popupType);
                     popup.setContent(view.asWidget());
                     break;
                 case CLOSE_DIALOG:
-                    popup = new Dialog(popupUiHandlers);
+                    popup = new Dialog(popupUiHandlers, popupType);
                     final CloseContent closeContent = new CloseContent(popupUiHandlers);
                     controls = closeContent;
                     closeContent.setContent(view.asWidget());
                     popup.setContent(closeContent);
                     break;
                 case OK_CANCEL_DIALOG:
-                    popup = new Dialog(popupUiHandlers);
+                    popup = new Dialog(popupUiHandlers, popupType);
                     final OkCancelContent okCancelContent = new OkCancelContent(popupUiHandlers);
                     controls = okCancelContent;
                     okCancelContent.setContent(view.asWidget());
                     popup.setContent(okCancelContent);
                     break;
                 case ACCEPT_REJECT_DIALOG:
-                    popup = new Dialog(popupUiHandlers);
+                    popup = new Dialog(popupUiHandlers, popupType);
                     final AcceptRejectContent acceptRejectContent = new AcceptRejectContent(popupUiHandlers);
                     controls = acceptRejectContent;
                     acceptRejectContent.setContent(view.asWidget());

--- a/stroom-core-client-widget/src/main/java/stroom/widget/popup/client/view/ResizableDialog.java
+++ b/stroom-core-client-widget/src/main/java/stroom/widget/popup/client/view/ResizableDialog.java
@@ -18,6 +18,7 @@ package stroom.widget.popup.client.view;
 
 import stroom.widget.popup.client.presenter.PopupSize;
 import stroom.widget.popup.client.presenter.PopupUiHandlers;
+import stroom.widget.popup.client.presenter.PopupView.PopupType;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Element;
@@ -69,8 +70,8 @@ public class ResizableDialog extends AbstractPopupPanel {
      * Creates an empty dialog box. It should not be shown until its child
      * widget has been added using {@link #add(Widget)}.
      */
-    ResizableDialog(final PopupUiHandlers popupUiHandlers, final PopupSize popupSize) {
-        this(popupUiHandlers, false, popupSize);
+    ResizableDialog(final PopupUiHandlers popupUiHandlers, final PopupSize popupSize, final PopupType popupType) {
+        this(popupUiHandlers, false, popupSize, popupType);
     }
 
     /**
@@ -81,8 +82,9 @@ public class ResizableDialog extends AbstractPopupPanel {
      * @param autoHide <code>true</code> if the dialog should be automatically hidden
      *                 when the user clicks outside of it
      */
-    private ResizableDialog(final PopupUiHandlers popupUiHandlers, final boolean autoHide, final PopupSize popupSize) {
-        this(popupUiHandlers, autoHide, true, popupSize);
+    private ResizableDialog(final PopupUiHandlers popupUiHandlers, final boolean autoHide, final PopupSize popupSize,
+                            final PopupType popupType) {
+        this(popupUiHandlers, autoHide, true, popupSize, popupType);
     }
 
     /**
@@ -96,8 +98,8 @@ public class ResizableDialog extends AbstractPopupPanel {
      *                 contained by the dialog should be ignored
      */
     private ResizableDialog(final PopupUiHandlers popupUiHandlers, final boolean autoHide, final boolean modal,
-                            final PopupSize popupSize) {
-        super(autoHide, modal);
+                            final PopupSize popupSize, final PopupType popupType) {
+        super(autoHide, modal, popupType);
         this.popupUiHandlers = popupUiHandlers;
         this.popupSize = popupSize;
 
@@ -157,6 +159,16 @@ public class ResizableDialog extends AbstractPopupPanel {
     @Override
     public void hide(final boolean autoClosed) {
         popupUiHandlers.onHideRequest(autoClosed, false);
+    }
+
+    @Override
+    protected void onEscapeKeyPressed() {
+        hide(false);
+    }
+
+    @Override
+    protected void onEnterKeyPressed() {
+        popupUiHandlers.onHideRequest(false, true);
     }
 
     @Override

--- a/stroom-core-client-widget/src/main/java/stroom/widget/popup/client/view/SimplePopup.java
+++ b/stroom-core-client-widget/src/main/java/stroom/widget/popup/client/view/SimplePopup.java
@@ -17,6 +17,7 @@
 package stroom.widget.popup.client.view;
 
 import stroom.widget.popup.client.presenter.PopupUiHandlers;
+import stroom.widget.popup.client.presenter.PopupView.PopupType;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.uibinder.client.UiBinder;
@@ -62,7 +63,7 @@ public class SimplePopup extends AbstractPopupPanel {
      *                 contained by the dialog should be ignored
      */
     public SimplePopup(final PopupUiHandlers popupUiHandlers, final boolean autoHide, final boolean modal) {
-        super(autoHide, modal);
+        super(autoHide, modal, PopupType.POPUP);
         this.popupUiHandlers = popupUiHandlers;
 
         setStyleName("simplePopup-popup");


### PR DESCRIPTION
Allow the user to dismiss a dialog using the keyboard:

- `Escape`: Hides the dialog, equivalent to pressing the `Cancel` button.
- `Ctrl+Enter`: Hides the dialog, returning a `true` result to the handler. Equivalent to pressing the `OK` button.