### PR TITLE
gchq/stroom-resources#104 Expose `stroom.ui.helpUrl` in the config.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+* Issue **gchq/stroom-resources#104** : Expose `stroom.ui.helpUrl` in the config.yml so the docs served by nginx can be accessed.
+
 
 ## [v7.0-beta.137] - 2021-07-02
 

--- a/stroom-app/prod.yml.jinja2
+++ b/stroom-app/prod.yml.jinja2
@@ -226,5 +226,12 @@ appConfig:
           jdbcDriverUrl: "{{ 'jdbc:mysql://localhost:3307/stats?useUnicode=yes&characterEncoding=UTF-8' | envVar('STROOM_STATISTICS_JDBC_DRIVER_URL') }}"
           jdbcDriverUsername: "{{ 'statsuser' | envVar('STROOM_STATISTICS_JDBC_DRIVER_USERNAME') }}"
           jdbcDriverPassword: "{{ 'stroompassword1' | envVar('STROOM_STATISTICS_JDBC_DRIVER_PASSWORD') }}"
+  {% if distribution == "docker" %}
+  ui:
+    helpUrl: "https://{{ 'localhost' | envVar('API_GATEWAY_HOST') }}/docs"
+  {% else %}
+  # ui:
+    # helpUrl: "https://<nginx host>/docs"
+  {% endif %}
 #
 # vim: set filetype=yaml tabstop=2 shiftwidth=2 expandtab:


### PR DESCRIPTION
Addresses gchq/stroom-resources#104