### PR TITLE
Fix IndexDoc Integer properties not being serialised

### DIFF
--- a/stroom-core-shared/src/main/java/stroom/index/shared/IndexDoc.java
+++ b/stroom-core-shared/src/main/java/stroom/index/shared/IndexDoc.java
@@ -129,11 +129,11 @@ public class IndexDoc extends Doc {
         this.description = description;
     }
 
-    public int getMaxDocsPerShard() {
+    public Integer getMaxDocsPerShard() {
         return maxDocsPerShard;
     }
 
-    public void setMaxDocsPerShard(final int maxDocsPerShard) {
+    public void setMaxDocsPerShard(final Integer maxDocsPerShard) {
         this.maxDocsPerShard = maxDocsPerShard;
     }
 
@@ -145,19 +145,19 @@ public class IndexDoc extends Doc {
         this.partitionBy = partitionBy;
     }
 
-    public int getPartitionSize() {
+    public Integer getPartitionSize() {
         return partitionSize;
     }
 
-    public void setPartitionSize(final int partitionSize) {
+    public void setPartitionSize(final Integer partitionSize) {
         this.partitionSize = partitionSize;
     }
 
-    public int getShardsPerPartition() {
+    public Integer getShardsPerPartition() {
         return shardsPerPartition;
     }
 
-    public void setShardsPerPartition(final int shardsPerPartition) {
+    public void setShardsPerPartition(final Integer shardsPerPartition) {
         this.shardsPerPartition = shardsPerPartition;
     }
 


### PR DESCRIPTION
During the migration to REST API services, the properties of `IndexDoc` were changed to type `Integer`. However the member accessors were not updated from type `int`.

This caused properties such as `partitionSize` and `shardsPerPartition` to not be serialised to JSON. See #2672.

This PR updates the property accessor data types such that serialisation occurs as expected.