### PR TITLE
PR for #2851 - stroom.statistics.impl.sql.ConnectionUtil has a hard coded > 1 sec slow SQL WARN, can this be configurable instead?

### DIFF
--- a/stroom-config/stroom-config-app/src/test/resources/stroom/config/app/expected.yaml
+++ b/stroom-config/stroom-config-app/src/test/resources/stroom/config/app/expected.yaml
@@ -811,6 +811,7 @@ appConfig:
       search:
         fetchSize: 5000
         maxResults: 100000
+      slowQueryWarningThreshold: "PT1S"
       statisticAggregationBatchSize: 1000000
   ui:
     aboutHtml: "<h1>About Stroom</h1><p>Stroom is designed to receive data from multiple\

--- a/stroom-statistics/stroom-statistics-impl-sql/src/main/java/stroom/statistics/impl/sql/ConnectionUtil.java
+++ b/stroom-statistics/stroom-statistics-impl-sql/src/main/java/stroom/statistics/impl/sql/ConnectionUtil.java
@@ -21,6 +21,7 @@ import stroom.util.logging.LambdaLogger;
 import stroom.util.logging.LambdaLoggerFactory;
 import stroom.util.logging.LogExecutionTime;
 import stroom.util.shared.ModelStringUtil;
+import stroom.util.time.StroomDuration;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -32,13 +33,22 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.inject.Provider;
 
 public class ConnectionUtil {
 
     private static final LambdaLogger LOGGER = LambdaLoggerFactory.getLogger(ConnectionUtil.class);
 
+    private final Provider<SQLStatisticsConfig> sqlStatisticsConfigProvider;
+
+    @Inject
+    public ConnectionUtil(final Provider<SQLStatisticsConfig> sqlStatisticsConfigProvider) {
+        this.sqlStatisticsConfigProvider = sqlStatisticsConfigProvider;
+    }
+
     @SuppressWarnings("SQL_PREPARED_STATEMENT_GENERATED_FROM_NONCONSTANT_STRING")
-    public static int executeUpdate(final Connection connection, final String sql, final List<Object> args)
+    public int executeUpdate(final Connection connection, final String sql, final List<Object> args)
             throws SQLException {
         logSql(sql, args);
         final LogExecutionTime logExecutionTime = new LogExecutionTime();
@@ -55,11 +65,11 @@ public class ConnectionUtil {
         }
     }
 
-    public static void executeStatement(final Connection connection, final String sql) throws SQLException {
+    public void executeStatement(final Connection connection, final String sql) throws SQLException {
         executeStatements(connection, Collections.singletonList(sql));
     }
 
-    public static void executeStatements(final Connection connection, final List<String> sqlStatements)
+    public void executeStatements(final Connection connection, final List<String> sqlStatements)
             throws SQLException {
         LOGGER.debug(() -> ">>> " + sqlStatements.stream()
                 .map(ConnectionUtil::cleanSqlForLogs)
@@ -97,7 +107,7 @@ public class ConnectionUtil {
     }
 
     @SuppressWarnings("SQL_PREPARED_STATEMENT_GENERATED_FROM_NONCONSTANT_STRING")
-    public static Long executeQueryLongResult(final Connection connection, final String sql, final List<Object> args)
+    public Long executeQueryLongResult(final Connection connection, final String sql, final List<Object> args)
             throws SQLException {
         logSql(sql, args);
         final LogExecutionTime logExecutionTime = new LogExecutionTime();
@@ -128,10 +138,10 @@ public class ConnectionUtil {
         }
     }
 
-    private static void logExecution(final LogExecutionTime logExecutionTime,
-                                     final Object result,
-                                     final String sql,
-                                     final List<Object> args) {
+    private void logExecution(final LogExecutionTime logExecutionTime,
+                              final Object result,
+                              final String sql,
+                              final List<Object> args) {
         if (result == null) {
             logExecution(logExecutionTime, () -> "", () -> sql, args);
         } else {
@@ -139,22 +149,32 @@ public class ConnectionUtil {
         }
     }
 
-    private static void logExecution(final LogExecutionTime logExecutionTime,
-                                     final Supplier<String> resultSupplier,
-                                     final Supplier<String> sqlSupplier,
-                                     final List<Object> args) {
+    private void logExecution(final LogExecutionTime logExecutionTime,
+                              final Supplier<String> resultSupplier,
+                              final Supplier<String> sqlSupplier,
+                              final List<Object> args) {
         final long time = logExecutionTime.getDuration();
-        if (LOGGER.isDebugEnabled() || time > 1000) {
+        final StroomDuration warningThreshold = sqlStatisticsConfigProvider.get()
+                .getSlowQueryWarningThreshold();
+        final long warningThresholdMs = warningThreshold.toMillis();
+
+        if (LOGGER.isDebugEnabled() || isSlowQueryWarningRequired(time, warningThresholdMs)) {
             final String sql = buildSQLTrace(sqlSupplier.get(), args);
-            final String message = "<<< " + sql + " "
+            final String message = "<<< " + sql
                     + " took " + ModelStringUtil.formatDurationString(time)
-                    + " with result " + resultSupplier.get();
-            if (time > 1000) {
-                LOGGER.warn(() -> message);
+                    + " with result " + resultSupplier.get() + ".";
+            if (isSlowQueryWarningRequired(time, warningThresholdMs)) {
+                LOGGER.warn(() -> message
+                        + " Warning threshold: " + warningThreshold
+                        + ". Set property stroom.statistics.sql.slowQueryWarningThreshold to change this threshold.");
             } else {
                 LOGGER.debug(() -> message);
             }
         }
+    }
+
+    private boolean isSlowQueryWarningRequired(final long timeMs, final long warningThresholdMs) {
+        return warningThresholdMs > 0 && timeMs > warningThresholdMs;
     }
 
     private static String cleanSqlForLogs(final String sql) {

--- a/stroom-statistics/stroom-statistics-impl-sql/src/main/java/stroom/statistics/impl/sql/SQLStatisticAggregationTransactionHelper.java
+++ b/stroom-statistics/stroom-statistics-impl-sql/src/main/java/stroom/statistics/impl/sql/SQLStatisticAggregationTransactionHelper.java
@@ -153,6 +153,7 @@ public class SQLStatisticAggregationTransactionHelper {
 
     private final SQLStatisticsDbConnProvider sqlStatisticsDbConnProvider;
     private final Provider<SQLStatisticsConfig> sqlStatisticsConfigProvider;
+    private final ConnectionUtil connectionUtil;
 
     // @formatter:on
     private final AggregateConfig[] aggregateConfig = new AggregateConfig[]{
@@ -187,9 +188,11 @@ public class SQLStatisticAggregationTransactionHelper {
 
     @Inject
     SQLStatisticAggregationTransactionHelper(final SQLStatisticsDbConnProvider sqlStatisticsDbConnProvider,
-                                             final Provider<SQLStatisticsConfig> sqlStatisticsConfigProvider) {
+                                             final Provider<SQLStatisticsConfig> sqlStatisticsConfigProvider,
+                                             final ConnectionUtil connectionUtil) {
         this.sqlStatisticsDbConnProvider = sqlStatisticsDbConnProvider;
         this.sqlStatisticsConfigProvider = sqlStatisticsConfigProvider;
+        this.connectionUtil = connectionUtil;
     }
 
     public static final long round(final long timeMs, final int precision) {
@@ -208,7 +211,7 @@ public class SQLStatisticAggregationTransactionHelper {
 
         taskContext.info(() -> prefix + "\n " + trace);
 
-        final int count = ConnectionUtil.executeUpdate(connection, sql, args);
+        final int count = connectionUtil.executeUpdate(connection, sql, args);
 
         LOGGER.debug(() -> LogUtil.message("doAggretateSQL - {} - {} in {} - {}",
                 prefix, ModelStringUtil.formatCsv(count), time, trace));
@@ -222,7 +225,7 @@ public class SQLStatisticAggregationTransactionHelper {
 
         taskContext.info(() -> prefix + "\n " + trace);
 
-        final long result = ConnectionUtil.executeQueryLongResult(connection, sql, args);
+        final long result = connectionUtil.executeQueryLongResult(connection, sql, args);
 
         LOGGER.debug("doAggretateSQL - {} - {} in {} - {}", prefix, ModelStringUtil.formatCsv(result), time, trace);
         return result;
@@ -236,7 +239,7 @@ public class SQLStatisticAggregationTransactionHelper {
                                              final String sql,
                                              final List<Object> args)
             throws SQLException {
-        return ConnectionUtil.executeQueryLongResult(connection, sql, args);
+        return connectionUtil.executeQueryLongResult(connection, sql, args);
     }
 
     public Long getAggregateMinId() throws SQLException {
@@ -307,7 +310,7 @@ public class SQLStatisticAggregationTransactionHelper {
 
             taskContext.info(() -> "\n " + sql);
 
-            final int count = ConnectionUtil.executeUpdate(
+            final int count = connectionUtil.executeUpdate(
                     connection,
                     DELETE_UNUSED_KEYS,
                     Collections.emptyList());

--- a/stroom-statistics/stroom-statistics-impl-sql/src/main/java/stroom/statistics/impl/sql/SQLStatisticsConfig.java
+++ b/stroom-statistics/stroom-statistics-impl-sql/src/main/java/stroom/statistics/impl/sql/SQLStatisticsConfig.java
@@ -27,6 +27,7 @@ public class SQLStatisticsConfig extends AbstractConfig implements HasDbConfig {
     // TODO 29/11/2021 AT: Make final
     private StroomDuration maxProcessingAge;
     private final CacheConfig dataSourceCache;
+    private final StroomDuration slowQueryWarningThreshold;
 
     public SQLStatisticsConfig() {
         dbConfig = new SQLStatisticsDbConfig();
@@ -38,22 +39,27 @@ public class SQLStatisticsConfig extends AbstractConfig implements HasDbConfig {
                 .maximumSize(100L)
                 .expireAfterAccess(StroomDuration.ofMinutes(10))
                 .build();
+        slowQueryWarningThreshold = StroomDuration.ofSeconds(1);
     }
 
     @SuppressWarnings("unused")
     @JsonCreator
-    public SQLStatisticsConfig(@JsonProperty("db") final SQLStatisticsDbConfig dbConfig,
-                               @JsonProperty("docRefType") final String docRefType,
-                               @JsonProperty("search") final SearchConfig searchConfig,
-                               @JsonProperty("statisticAggregationBatchSize") final int statisticAggregationBatchSize,
-                               @JsonProperty("maxProcessingAge") final StroomDuration maxProcessingAge,
-                               @JsonProperty("dataSourceCache") final CacheConfig dataSourceCache) {
+    public SQLStatisticsConfig(
+            @JsonProperty("db") final SQLStatisticsDbConfig dbConfig,
+            @JsonProperty("docRefType") final String docRefType,
+            @JsonProperty("search") final SearchConfig searchConfig,
+            @JsonProperty("statisticAggregationBatchSize") final int statisticAggregationBatchSize,
+            @JsonProperty("maxProcessingAge") final StroomDuration maxProcessingAge,
+            @JsonProperty("dataSourceCache") final CacheConfig dataSourceCache,
+            @JsonProperty("slowQueryWarningThreshold") final StroomDuration slowQueryWarningThreshold) {
+
         this.dbConfig = dbConfig;
         this.docRefType = docRefType;
         this.searchConfig = searchConfig;
         this.statisticAggregationBatchSize = statisticAggregationBatchSize;
         this.maxProcessingAge = maxProcessingAge;
         this.dataSourceCache = dataSourceCache;
+        this.slowQueryWarningThreshold = slowQueryWarningThreshold;
     }
 
     @Override
@@ -95,6 +101,12 @@ public class SQLStatisticsConfig extends AbstractConfig implements HasDbConfig {
         return dataSourceCache;
     }
 
+    @JsonPropertyDescription("A warning will be logged for any statistics database queries that take longer than " +
+            "this threshold to complete. A value of '0' or 'PT0' means no warnings will be logged at all.")
+    public StroomDuration getSlowQueryWarningThreshold() {
+        return slowQueryWarningThreshold;
+    }
+
     public SQLStatisticsConfig withMaxProcessingAge(final StroomDuration maxProcessingAge) {
         return new SQLStatisticsConfig(
                 dbConfig,
@@ -102,7 +114,7 @@ public class SQLStatisticsConfig extends AbstractConfig implements HasDbConfig {
                 searchConfig,
                 statisticAggregationBatchSize,
                 maxProcessingAge,
-                dataSourceCache);
+                dataSourceCache, slowQueryWarningThreshold);
     }
 
     @Override

--- a/unreleased_changes/20220427_115333_941__2851.md
+++ b/unreleased_changes/20220427_115333_941__2851.md
@@ -1,0 +1,24 @@
+* Issue **#2851** : Add configuration property `stroom.statistics.sql.slowQueryWarningThreshold` to configure slow statistics sql query warning threshold.
+
+
+```sh
+# ********************************************************************************
+# Issue title: stroom.statistics.impl.sql.ConnectionUtil has a hard coded > 1 sec slow SQL WARN, can this be configurable instead?
+# Issue link:  https://github.com/gchq/stroom/issues/2851
+# ********************************************************************************
+
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Issue **123** : Fix bug with an associated GitHub issue in this repository
+#
+# * Issue **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository
+#
+# * Fix bug with no associated GitHub issue.
+```


### PR DESCRIPTION
Fixes #2851