### PR TITLE
Track whether a `ByteCountOutputStream` stream is empty

### DIFF
--- a/stroom-pipeline/src/main/java/stroom/pipeline/destination/RollingDestination.java
+++ b/stroom-pipeline/src/main/java/stroom/pipeline/destination/RollingDestination.java
@@ -109,7 +109,7 @@ public abstract class RollingDestination implements Destination {
 
         // If we haven't written yet then create the output stream and
         // write a header if we have one.
-        if (header != null && header.length > 0 && outputStream != null && outputStream.getCount() == 0) {
+        if (header != null && header.length > 0 && outputStream != null && outputStream.isEmpty()) {
             // Write the header.
             write(header);
         }
@@ -178,7 +178,7 @@ public abstract class RollingDestination implements Destination {
         beforeRoll(exceptions::add);
 
         // If we have written any data then write a footer if we have one.
-        if (footer != null && footer.length > 0 && outputStream != null && outputStream.getCount() > 0) {
+        if (footer != null && footer.length > 0 && outputStream != null && !outputStream.isEmpty()) {
             // Write the footer.
             try {
                 write(footer);

--- a/stroom-util/src/main/java/stroom/util/io/ByteCountOutputStream.java
+++ b/stroom-util/src/main/java/stroom/util/io/ByteCountOutputStream.java
@@ -18,11 +18,13 @@ package stroom.util.io;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class ByteCountOutputStream extends WrappedOutputStream {
 
     private final AtomicLong count = new AtomicLong();
+    private final AtomicBoolean isEmpty = new AtomicBoolean(true);
 
     public ByteCountOutputStream(final OutputStream outputStream) {
         super(outputStream);
@@ -31,22 +33,29 @@ public class ByteCountOutputStream extends WrappedOutputStream {
     @Override
     public void write(final int b) throws IOException {
         count.incrementAndGet();
+        isEmpty.set(false);
         super.write(b);
     }
 
     @Override
     public void write(final byte[] b) throws IOException {
         count.addAndGet(b.length);
+        isEmpty.set(false);
         super.write(b);
     }
 
     @Override
     public void write(final byte[] b, final int off, final int len) throws IOException {
         count.addAndGet(len);
+        isEmpty.set(false);
         super.write(b, off, len);
     }
 
     public long getCount() {
         return count.get();
+    }
+
+    public boolean isEmpty() {
+        return isEmpty.get();
     }
 }

--- a/unreleased_changes/20220726_131211_183__3012.md
+++ b/unreleased_changes/20220726_131211_183__3012.md
@@ -1,4 +1,4 @@
-* Issue **#3012** : Do not write header twice in RollingFileAppender with compression enabled.
+* Issue **#3012** : Do not write header for each record in RollingFileAppender with compression enabled.
 
 
 ```sh

--- a/unreleased_changes/20220726_131211_183__3012.md
+++ b/unreleased_changes/20220726_131211_183__3012.md
@@ -1,0 +1,19 @@
+* Issue **#3012** : Do not write header twice in RollingFileAppender with compression enabled.
+
+
+```sh
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Issue **123** : Fix bug with an associated GitHub issue in this repository
+#
+# * Issue **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository
+#
+# * Fix bug with no associated GitHub issue.
+```


### PR DESCRIPTION
When `RollingFileAppender` writes to a destination with compression enabled, `GZIPOutputStream` first writes a GZIP header to the file.

The current implementation of `RollingDestination` checks the number of bytes written and if greater than zero, writes the XML document header. The problem with this approach is that compressed streams always have a size > 0, so the header is written for each and every event.

This PR adds a `isEmpty` property and corresponding accessor to `ByteCountOutputStream` that is simply set to `false` when any write occurs. This ensures the presence of any data can be tracked, regardless of the use of compression.

Therefore, closes #3012.