### PR TITLE
Just trim whitespace instead of trying to escape it and double-quotes

### DIFF
--- a/stroom-core-client/src/main/java/stroom/query/client/ExpressionModel.java
+++ b/stroom-core-client/src/main/java/stroom/query/client/ExpressionModel.java
@@ -67,9 +67,7 @@ public class ExpressionModel {
                 final Term term = new Term();
                 term.setField(expressionTerm.getField());
                 term.setCondition(expressionTerm.getCondition());
-                // If the value contains any trailing/leading whitespace we need to surround with dbl quotes.
-                // Also, first escape any dbl quotes in the value
-                term.setValue(StringUtil.addWhitespaceQuoting(expressionTerm.getValue()));
+                term.setValue(StringUtil.trimWhitespace(expressionTerm.getValue()));
                 term.setDocRef(expressionTerm.getDocRef());
                 term.setEnabled(expressionTerm.enabled());
 
@@ -112,10 +110,7 @@ public class ExpressionModel {
                     dest.addOperator(childDest.build());
                 } else if (child instanceof Term) {
                     final Term term = (Term) child;
-                    // The user can add dbl quotes to explicitly include leading/trailing white space,
-                    // which would otherwise be removed. They can also do \" to escape actual dbl quotes.
-                    // Remove quoting and un-escape escaped dbl quotes. Trim un-quoted white space.
-                    final String termValue = StringUtil.removeWhitespaceQuoting(term.getValue());
+                    final String termValue = StringUtil.trimWhitespace(term.getValue());
 
                     dest.addTerm(ExpressionTerm.builder()
                             .enabled(term.isEnabled())

--- a/stroom-core-client/src/main/java/stroom/query/client/TermEditor.java
+++ b/stroom-core-client/src/main/java/stroom/query/client/TermEditor.java
@@ -209,10 +209,7 @@ public class TermEditor extends Composite {
                 sb.setLength(sb.length() - 1);
             }
 
-            // Remove, then add whitespace quoting so the un-focused term value shows the user
-            // the value with the correct quoting based on what they have entered
-            term.setValue(StringUtil.addWhitespaceQuoting(
-                    StringUtil.removeWhitespaceQuoting(sb.toString())));
+            term.setValue(StringUtil.trimWhitespace(sb.toString()));
             term.setDocRef(docRef);
         }
     }

--- a/stroom-query/stroom-query-api/src/main/java/stroom/query/api/v2/ExpressionTerm.java
+++ b/stroom-query/stroom-query-api/src/main/java/stroom/query/api/v2/ExpressionTerm.java
@@ -157,9 +157,7 @@ public final class ExpressionTerm extends ExpressionItem {
                 } else if (Condition.IS_DOC_REF.equals(condition)) {
                     appendDocRef(sb, docRef);
                 } else if (value != null) {
-                    // This will dbl quote anything with leading/trailing whitespace and if it
-                    // does that it will escape any actual dbl quotes in the value.
-                    sb.append(StringUtil.addWhitespaceQuoting(value));
+                    sb.append(StringUtil.trimWhitespace(value));
                 }
             }
         }

--- a/stroom-util-shared/src/main/java/stroom/util/shared/StringUtil.java
+++ b/stroom-util-shared/src/main/java/stroom/util/shared/StringUtil.java
@@ -52,6 +52,67 @@ public class StringUtil {
         }
     }
 
+    /**
+     * Converts user input, that has been double-quoted to include whitespace,
+     * into the un-quoted value. Any double quotes inside the outermost double
+     * quotes will be escaped with a single backslash. Any Unquoted whitespace
+     * or whitespace outside the outer double quotes will be trimmed.
+     * See the tests for examples.
+     */
+    public static String removeWhitespaceQuoting(final String userText) {
+        final String storedText;
+        if (userText == null || userText.isEmpty()) {
+            storedText = userText;
+        } else {
+            final String trimmedStr = userText.trim();
+            if (trimmedStr.startsWith("\"")
+                    && trimmedStr.endsWith("\"")) {
+
+                final int openQuoteIdx = trimmedStr.indexOf("\"");
+                final int endQuoteIdx = trimmedStr.lastIndexOf("\"");
+                if (openQuoteIdx == endQuoteIdx) {
+                    // '"'
+                    storedText = trimmedStr;
+                } else {
+                    // Everything inside the db quotes, un-escaping any dbl quote used
+                    storedText = trimmedStr.substring(openQuoteIdx + 1, endQuoteIdx)
+                            .replace("\\\"", "\"");
+                }
+            } else {
+                storedText = trimmedStr.replace("\\\"", "\"");
+            }
+        }
+        return storedText;
+    }
+
+    /**
+     * Converts a system stored value into one for display in the UI.
+     * If the value has leading or trailing whitespace it will be quoted and any
+     * double quotes escaped.
+     * See the tests for examples.
+     */
+    public static String addWhitespaceQuoting(final String storedText) {
+        String userText;
+        if (storedText == null || storedText.isEmpty()) {
+            userText = storedText;
+        } else {
+            final String escapedText = storedText.replace("\"", "\\\"");
+            if (storedText.startsWith(" ")
+                    || storedText.startsWith("\t")
+                    || storedText.endsWith(" ")
+                    || storedText.endsWith("\t")) {
+                // leading/trailing whitespace so dbl quote the whole thing
+                // ' he said "hello" ' => '" he said \"hello\" "'
+                userText = "\""
+                        + escapedText
+                        + "\"";
+            } else {
+                userText = escapedText;
+            }
+        }
+        return userText;
+    }
+
     public static String pluralSuffix(final int count) {
         return count > 1
                 ? "s"

--- a/stroom-util-shared/src/main/java/stroom/util/shared/StringUtil.java
+++ b/stroom-util-shared/src/main/java/stroom/util/shared/StringUtil.java
@@ -44,65 +44,12 @@ public class StringUtil {
         }
     }
 
-    /**
-     * Converts user input, that has been double-quoted to include whitespace,
-     * into the un-quoted value. Any double quotes inside the outermost double
-     * quotes will be escaped with a single backslash. Any Unquoted whitespace
-     * or whitespace outside the outer double quotes will be trimmed.
-     * See the tests for examples.
-     */
-    public static String removeWhitespaceQuoting(final String userText) {
-        final String storedText;
+    public static String trimWhitespace(final String userText) {
         if (userText == null || userText.isEmpty()) {
-            storedText = userText;
+            return userText;
         } else {
-            final String trimmedStr = userText.trim();
-            if (trimmedStr.startsWith("\"")
-                    && trimmedStr.endsWith("\"")) {
-
-                final int openQuoteIdx = trimmedStr.indexOf("\"");
-                final int endQuoteIdx = trimmedStr.lastIndexOf("\"");
-                if (openQuoteIdx == endQuoteIdx) {
-                    // '"'
-                    storedText = trimmedStr;
-                } else {
-                    // Everything inside the db quotes, un-escaping any dbl quote used
-                    storedText = trimmedStr.substring(openQuoteIdx + 1, endQuoteIdx)
-                            .replace("\\\"", "\"");
-                }
-            } else {
-                storedText = trimmedStr.replace("\\\"", "\"");
-            }
+            return userText.trim();
         }
-        return storedText;
-    }
-
-    /**
-     * Converts a system stored value into one for display in the UI.
-     * If the value has leading or trailing whitespace it will be quoted and any
-     * double quotes escaped.
-     * See the tests for examples.
-     */
-    public static String addWhitespaceQuoting(final String storedText) {
-        String userText;
-        if (storedText == null || storedText.isEmpty()) {
-            userText = storedText;
-        } else {
-            final String escapedText = storedText.replace("\"", "\\\"");
-            if (storedText.startsWith(" ")
-                    || storedText.startsWith("\t")
-                    || storedText.endsWith(" ")
-                    || storedText.endsWith("\t")) {
-                // leading/trailing whitespace so dbl quote the whole thing
-                // ' he said "hello" ' => '" he said \"hello\" "'
-                userText = "\""
-                        + escapedText
-                        + "\"";
-            } else {
-                userText = escapedText;
-            }
-        }
-        return userText;
     }
 
     public static String pluralSuffix(final int count) {


### PR DESCRIPTION
The recent change with #3113 strips quote characters surrounding a term. The workaround is for users to manually escape these (e.g. `\"term value\"`), which is less than ideal - as the quotes are otherwise silently removed.

The original issue #3111 simply called for whitespace to be ignored (i.e. removed). This PR brings behaviour inline with that request, preserving quotes surrounding the term value in the process. Any internal whitespace will be preserved, without the need for escaping.