### PR TITLE
Increase default width of global property editor dialog

### DIFF
--- a/stroom-app/src/main/resources/ui/css/components.css
+++ b/stroom-app/src/main/resources/ui/css/components.css
@@ -1226,8 +1226,8 @@
 }
 
 .globalPropertyEditViewImpl-textArea {
-    width:100%;
-    height:80px;
+    width: 100%;
+    height: 100px;
 }
 .globalPropertyEditViewImpl-textAreaReducedHeight {
     width:100%;

--- a/stroom-app/src/main/resources/ui/css/webkit-scrollbar.css
+++ b/stroom-app/src/main/resources/ui/css/webkit-scrollbar.css
@@ -26,6 +26,7 @@
 
 /* Track */
 ::-webkit-scrollbar-track {
+	background: var(--scrollbar-background-color);
 }
 
 /* Corner */

--- a/stroom-core-client-widget/src/main/java/stroom/widget/popup/client/presenter/PopupSize.java
+++ b/stroom-core-client-widget/src/main/java/stroom/widget/popup/client/presenter/PopupSize.java
@@ -49,9 +49,21 @@ public class PopupSize {
                 .build();
     }
 
+    public static PopupSize resizableX(int initialWidth) {
+        return PopupSize.builder()
+                .width(Size.builder().initial(initialWidth).resizable(true).build())
+                .build();
+    }
+
     public static PopupSize resizableX() {
         return PopupSize.builder()
                 .width(Size.builder().resizable(true).build())
+                .build();
+    }
+
+    public static PopupSize resizableY(int initialHeight) {
+        return PopupSize.builder()
+                .height(Size.builder().initial(initialHeight).resizable(true).build())
                 .build();
     }
 

--- a/stroom-core-client/src/main/java/stroom/config/global/client/presenter/ManageGlobalPropertyEditPresenter.java
+++ b/stroom-core-client/src/main/java/stroom/config/global/client/presenter/ManageGlobalPropertyEditPresenter.java
@@ -537,8 +537,8 @@ public final class ManageGlobalPropertyEditPresenter
         setUiSourceText();
     }
 
-    protected PopupSize getPopupSize() {
-        return PopupSize.resizableX();
+    private PopupSize getPopupSize() {
+        return PopupSize.resizableX(500);
     }
 
     @Override

--- a/unreleased_changes/20221229_132553_068__3141.md
+++ b/unreleased_changes/20221229_132553_068__3141.md
@@ -1,0 +1,19 @@
+* Issue **#3141** : Increase default width of global property editor dialog.
+
+
+```sh
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Issue **123** : Fix bug with an associated GitHub issue in this repository
+#
+# * Issue **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository
+#
+# * Fix bug with no associated GitHub issue.
+```


### PR DESCRIPTION
Closes #3141 

Also resolves the `textarea` scrollbar track not having a dark background.

![image](https://user-images.githubusercontent.com/17559369/209960428-970f4807-4ee4-444f-ba79-cc298e533734.png)
