### PR TITLE
gh-3111 Revert prev change, now just trim term whitespace

### DIFF
--- a/stroom-core-client/src/main/java/stroom/query/client/ExpressionModel.java
+++ b/stroom-core-client/src/main/java/stroom/query/client/ExpressionModel.java
@@ -67,9 +67,7 @@ public class ExpressionModel {
                 final Term term = new Term();
                 term.setField(expressionTerm.getField());
                 term.setCondition(expressionTerm.getCondition());
-                // If the value contains any trailing/leading whitespace we need to surround with dbl quotes.
-                // Also, first escape any dbl quotes in the value
-                term.setValue(StringUtil.addWhitespaceQuoting(expressionTerm.getValue()));
+                term.setValue(StringUtil.trimWhitespace(expressionTerm.getValue()));
                 term.setDocRef(expressionTerm.getDocRef());
                 term.setEnabled(expressionTerm.enabled());
 
@@ -112,10 +110,7 @@ public class ExpressionModel {
                     dest.addOperator(childDest.build());
                 } else if (child instanceof Term) {
                     final Term term = (Term) child;
-                    // The user can add dbl quotes to explicitly include leading/trailing white space,
-                    // which would otherwise be removed. They can also do \" to escape actual dbl quotes.
-                    // Remove quoting and un-escape escaped dbl quotes. Trim un-quoted white space.
-                    final String termValue = StringUtil.removeWhitespaceQuoting(term.getValue());
+                    final String termValue = StringUtil.trimWhitespace(term.getValue());
 
                     dest.addTerm(ExpressionTerm.builder()
                             .enabled(term.isEnabled())

--- a/stroom-core-client/src/main/java/stroom/query/client/TermEditor.java
+++ b/stroom-core-client/src/main/java/stroom/query/client/TermEditor.java
@@ -218,10 +218,7 @@ public class TermEditor extends Composite {
                 sb.setLength(sb.length() - 1);
             }
 
-            // Remove, then add whitespace quoting so the un-focused term value shows the user
-            // the value with the correct quoting based on what they have entered
-            term.setValue(StringUtil.addWhitespaceQuoting(
-                    StringUtil.removeWhitespaceQuoting(sb.toString())));
+            term.setValue(StringUtil.trimWhitespace(sb.toString()));
             term.setDocRef(docRef);
         }
     }

--- a/stroom-query/stroom-query-api/src/main/java/stroom/query/api/v2/ExpressionTerm.java
+++ b/stroom-query/stroom-query-api/src/main/java/stroom/query/api/v2/ExpressionTerm.java
@@ -157,9 +157,7 @@ public final class ExpressionTerm extends ExpressionItem {
                 } else if (Condition.IS_DOC_REF.equals(condition)) {
                     appendDocRef(sb, docRef);
                 } else if (value != null) {
-                    // This will dbl quote anything with leading/trailing whitespace and if it
-                    // does that it will escape any actual dbl quotes in the value.
-                    sb.append(StringUtil.addWhitespaceQuoting(value));
+                    sb.append(StringUtil.trimWhitespace(value));
                 }
             }
         }

--- a/stroom-util-shared/src/main/java/stroom/util/shared/StringUtil.java
+++ b/stroom-util-shared/src/main/java/stroom/util/shared/StringUtil.java
@@ -110,4 +110,15 @@ public class StringUtil {
                 ? "s"
                 : "";
     }
+
+    /**
+     * Null safe trimming of leading/trailing whitespace.
+     */
+    public static String trimWhitespace(final String userText) {
+        if (userText == null || userText.isEmpty()) {
+            return userText;
+        } else {
+            return userText.trim();
+        }
+    }
 }

--- a/unreleased_changes/20230113_091421_364__3111.md
+++ b/unreleased_changes/20230113_091421_364__3111.md
@@ -1,0 +1,24 @@
+* Issue **#3111** : Revert previous change that added double quote handling. Now we only trim leading/trailing whitespace from expression terms.
+
+
+```sh
+# ********************************************************************************
+# Issue title: Stream Filters coping with trailing spaces
+# Issue link:  https://github.com/gchq/stroom/issues/3111
+# ********************************************************************************
+
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Issue **123** : Fix bug with an associated GitHub issue in this repository
+#
+# * Issue **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository
+#
+# * Fix bug with no associated GitHub issue.
+```


### PR DESCRIPTION
This recreates PR #3157 but with 7.0 as the base.

Reverts the change made in #3113 and now just trims whitespace.

Relates to issue #3111 