### PR TITLE
Add export all info logging

### DIFF
--- a/stroom-app/src/test/java/stroom/importexport/TestImportExportDashboards.java
+++ b/stroom-app/src/test/java/stroom/importexport/TestImportExportDashboards.java
@@ -228,11 +228,11 @@ class TestImportExportDashboards extends AbstractCoreIntegrationTest {
         }
 
         // Export all
-        importExportService.exportConfig(docRefs, resourceStore.getTempFile(file), new ArrayList<>());
+        importExportService.exportConfig(docRefs, resourceStore.getTempFile(file));
 
         final ResourceKey exportConfig = resourceStore.createTempFile("ExportPlain.zip");
 
-        importExportService.exportConfig(docRefs, resourceStore.getTempFile(exportConfig), new ArrayList<>());
+        importExportService.exportConfig(docRefs, resourceStore.getTempFile(exportConfig));
 
         if (!update) {
             // Delete everything.

--- a/stroom-app/src/test/java/stroom/importexport/TestImportExportSerializer.java
+++ b/stroom-app/src/test/java/stroom/importexport/TestImportExportSerializer.java
@@ -24,6 +24,7 @@ import stroom.explorer.api.ExplorerService;
 import stroom.explorer.shared.ExplorerConstants;
 import stroom.feed.api.FeedStore;
 import stroom.feed.shared.FeedDoc;
+import stroom.importexport.api.ExportSummary;
 import stroom.importexport.impl.ImportExportFileNameUtil;
 import stroom.importexport.impl.ImportExportSerializer;
 import stroom.importexport.shared.ImportSettings;
@@ -117,7 +118,7 @@ class TestImportExportSerializer extends AbstractCoreIntegrationTest {
         FileUtil.deleteDir(testDataDir);
         Files.createDirectories(testDataDir);
 
-        importExportSerializer.write(testDataDir, buildFindFolderCriteria(), true, new ArrayList<>());
+        importExportSerializer.write(testDataDir, buildFindFolderCriteria(), true);
 
         List<ImportState> list = new ArrayList<>();
         importExportSerializer.read(testDataDir, list, ImportSettings.createConfirmation());
@@ -212,7 +213,7 @@ class TestImportExportSerializer extends AbstractCoreIntegrationTest {
 
 
         System.err.println("Exporting to " + testDataDir);
-        importExportSerializer.write(testDataDir, forExport, true, new ArrayList<>());
+        importExportSerializer.write(testDataDir, forExport, true);
 
 
         importExportSerializer.read(testDataDir, null, ImportSettings.auto());
@@ -239,7 +240,7 @@ class TestImportExportSerializer extends AbstractCoreIntegrationTest {
         FileUtil.deleteDir(testDataDir);
         Files.createDirectories(testDataDir);
 
-        importExportSerializer.write(testDataDir, buildFindFolderCriteria(), true, new ArrayList<>());
+        importExportSerializer.write(testDataDir, buildFindFolderCriteria(), true);
 
         final String fileNamePrefix = ImportExportFileNameUtil.createFilePrefix(childPipelineRef);
         final String fileName = fileNamePrefix + ".meta";
@@ -276,9 +277,9 @@ class TestImportExportSerializer extends AbstractCoreIntegrationTest {
                 importExportSerializer.read(inDir, null, ImportSettings.auto());
 
         // Write to output.
-        List<Message> messageList = new ArrayList<>();
-        importExportSerializer.write(outDir, exported, true, messageList);
+        final ExportSummary exportSummary = importExportSerializer.write(outDir, exported, true);
 
+        final List<Message> messageList = exportSummary.getMessages();
         messageList.forEach(message -> {
             if (message.getSeverity().equals(Severity.ERROR)) {
                 LOGGER.error("Export error: {}", message.getMessage());

--- a/stroom-app/src/test/java/stroom/importexport/TestImportExportServiceImpl.java
+++ b/stroom-app/src/test/java/stroom/importexport/TestImportExportServiceImpl.java
@@ -139,11 +139,11 @@ class TestImportExportServiceImpl extends AbstractCoreIntegrationTest {
         docRefs.add(folder2);
 
         // Export
-        importExportService.exportConfig(docRefs, resourceStore.getTempFile(file), null);
+        importExportService.exportConfig(docRefs, resourceStore.getTempFile(file));
 
         final ResourceKey exportConfig = resourceStore.createTempFile("ExportPlain.zip");
 
-        importExportService.exportConfig(docRefs, resourceStore.getTempFile(exportConfig), null);
+        importExportService.exportConfig(docRefs, resourceStore.getTempFile(exportConfig));
 
         // Delete it and check
         pipelineStore.deleteDocument(tran2.getUuid());
@@ -175,6 +175,6 @@ class TestImportExportServiceImpl extends AbstractCoreIntegrationTest {
         criteriaChild.add(folder2child2);
 
         // Export
-        importExportService.exportConfig(criteriaChild, resourceStore.getTempFile(fileChild), null);
+        importExportService.exportConfig(criteriaChild, resourceStore.getTempFile(fileChild));
     }
 }

--- a/stroom-app/src/test/java/stroom/importexport/TestImportExportServiceImpl3.java
+++ b/stroom-app/src/test/java/stroom/importexport/TestImportExportServiceImpl3.java
@@ -59,7 +59,7 @@ class TestImportExportServiceImpl3 extends AbstractCoreIntegrationTest {
         final Path testFile = getCurrentTestDir()
                 .resolve("ExportTest" + FileSystemTestUtil.getUniqueTestString() + ".zip");
 
-        importExportService.exportConfig(null, testFile, msgList);
+        importExportService.exportConfig(null, testFile);
 
         assertThat(msgList.size())
                 .isEqualTo(0);

--- a/stroom-app/src/test/java/stroom/statistics/impl/hbase/TestStroomStatsStoreImportExportSerializer.java
+++ b/stroom-app/src/test/java/stroom/statistics/impl/hbase/TestStroomStatsStoreImportExportSerializer.java
@@ -74,7 +74,7 @@ class TestStroomStatsStoreImportExportSerializer extends AbstractCoreIntegration
         FileUtil.deleteDir(testDataDir);
         FileUtil.mkdirs(testDataDir);
 
-        importExportSerializer.write(testDataDir, Set.of(docRef), true, null);
+        importExportSerializer.write(testDataDir, Set.of(docRef), true);
 
         assertThat(FileUtil.count(testDataDir)).isEqualTo(2);
 

--- a/stroom-app/src/test/java/stroom/statistics/impl/sql/TestStatisticsDataSourceImportExportSerializer.java
+++ b/stroom-app/src/test/java/stroom/statistics/impl/sql/TestStatisticsDataSourceImportExportSerializer.java
@@ -88,7 +88,7 @@ class TestStatisticsDataSourceImportExportSerializer extends AbstractCoreIntegra
         FileUtil.deleteDir(testDataDir);
         FileUtil.mkdirs(testDataDir);
 
-        importExportSerializer.write(testDataDir, buildFindFolderCriteria(), true, null);
+        importExportSerializer.write(testDataDir, buildFindFolderCriteria(), true);
 
         assertThat(FileUtil.count(testDataDir)).isEqualTo(2);
 

--- a/stroom-importexport/stroom-importexport-api/src/main/java/stroom/importexport/api/ExportSummary.java
+++ b/stroom-importexport/stroom-importexport-api/src/main/java/stroom/importexport/api/ExportSummary.java
@@ -1,0 +1,53 @@
+package stroom.importexport.api;
+
+import stroom.util.shared.Message;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ExportSummary {
+
+    private final Map<String, Integer> successCountsByType = new HashMap<>();
+    private final Map<String, Integer> failedCountsByType = new HashMap<>();
+    private List<Message> messages = Collections.emptyList();
+
+    public void addSuccess(final String type) {
+        successCountsByType.merge(type, 1, Integer::sum);
+    }
+
+    public void addFailure(final String type) {
+        failedCountsByType.merge(type, 1, Integer::sum);
+    }
+
+    public List<Message> getMessages() {
+        return messages;
+    }
+
+    public void setMessages(final List<Message> messages) {
+        this.messages = messages;
+    }
+
+    public Map<String, Integer> getFailedCountsByType() {
+        return failedCountsByType;
+    }
+
+    public Map<String, Integer> getSuccessCountsByType() {
+        return successCountsByType;
+    }
+
+    public int getSuccessTotal() {
+        return successCountsByType.values()
+                .stream()
+                .mapToInt(i -> i)
+                .sum();
+    }
+
+    public int getFailedTotal() {
+        return failedCountsByType.values()
+                .stream()
+                .mapToInt(i -> i)
+                .sum();
+    }
+}

--- a/stroom-importexport/stroom-importexport-impl/build.gradle
+++ b/stroom-importexport/stroom-importexport-impl/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     compile libs.slf4j_api
     compile project(':stroom-docref')
     compile libs.swagger_annotations
+    compile libs.vavr
     compile libs.ws_rs_api
 
     testCompile project(':stroom-test-common')

--- a/stroom-importexport/stroom-importexport-impl/src/main/java/stroom/importexport/impl/ContentServiceImpl.java
+++ b/stroom-importexport/stroom-importexport-impl/src/main/java/stroom/importexport/impl/ContentServiceImpl.java
@@ -132,7 +132,7 @@ class ContentServiceImpl implements ContentService {
         Objects.requireNonNull(docRefs);
 
         return securityContext.secureResult(PermissionNames.EXPORT_CONFIGURATION, () -> {
-            ResourceStore resourceStore = this.resourceStore;
+            final ResourceStore resourceStore = this.resourceStore;
             final ResourceKey guiKey = resourceStore.createTempFile("StroomConfig.zip");
             final Path file = resourceStore.getTempFile(guiKey);
             final ExportSummary exportSummary = importExportService.exportConfig(docRefs.getDocRefs(), file);
@@ -149,7 +149,7 @@ class ContentServiceImpl implements ContentService {
 
     @Override
     public ResourceKey exportAll() {
-        if (!securityContext.hasAppPermission("Export Configuration")) {
+        if (!securityContext.hasAppPermission(PermissionNames.EXPORT_CONFIGURATION)) {
             throw new PermissionException(securityContext.getUserId(),
                     "You do not have permission to export all config");
         }

--- a/stroom-importexport/stroom-importexport-impl/src/main/java/stroom/importexport/impl/ExportConfig.java
+++ b/stroom-importexport/stroom-importexport-impl/src/main/java/stroom/importexport/impl/ExportConfig.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @JsonPropertyOrder(alphabetic = true)
 public class ExportConfig extends AbstractConfig {
 
+    protected static final String ENABLED_PROP_NAME = "enabled";
     private final boolean enabled;
 
     public ExportConfig() {
@@ -18,7 +19,7 @@ public class ExportConfig extends AbstractConfig {
     }
 
     @JsonCreator
-    public ExportConfig(@JsonProperty("enabled") final boolean enabled) {
+    public ExportConfig(@JsonProperty(ENABLED_PROP_NAME) final boolean enabled) {
         this.enabled = enabled;
     }
 

--- a/stroom-importexport/stroom-importexport-impl/src/main/java/stroom/importexport/impl/ExportContentResourceImpl.java
+++ b/stroom-importexport/stroom-importexport-impl/src/main/java/stroom/importexport/impl/ExportContentResourceImpl.java
@@ -33,7 +33,7 @@ public class ExportContentResourceImpl implements ExportContentResource {
     @AutoLogged(value = OperationType.EXPORT, verb = "Exporting All Config")
     public Response export() {
 
-        ResourceKey tempResourceKey = contentServiceProvider.get().exportAll();
+        final ResourceKey tempResourceKey = contentServiceProvider.get().exportAll();
         final Path tempFile = resourceStoreProvider.get().getTempFile(tempResourceKey);
 
         final StreamingOutput streamingOutput = output -> {

--- a/stroom-importexport/stroom-importexport-impl/src/main/java/stroom/importexport/impl/ImportExportSerializer.java
+++ b/stroom-importexport/stroom-importexport-impl/src/main/java/stroom/importexport/impl/ImportExportSerializer.java
@@ -17,9 +17,9 @@
 package stroom.importexport.impl;
 
 import stroom.docref.DocRef;
+import stroom.importexport.api.ExportSummary;
 import stroom.importexport.shared.ImportSettings;
 import stroom.importexport.shared.ImportState;
-import stroom.util.shared.Message;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -43,12 +43,14 @@ public interface ImportExportSerializer {
 
     /**
      * Walk the supplied tree of DocRefs and export all to the given path
-     *
-     * @param dir             Where to serialize the DocRef items to.
+     *  @param dir             Where to serialize the DocRef items to.
      * @param docRefs         Set of the DocRefs and root folder DocRefs (as per that returned by
      *                        ImportExportSerializer.read()
      * @param omitAuditFields do not export audit fields (e.g. last update time / last update user)
      * @param messageList
+     * @return
      */
-    void write(Path dir, Set<DocRef> docRefs, boolean omitAuditFields, List<Message> messageList);
+    ExportSummary write(final Path dir,
+                        final Set<DocRef> docRefs,
+                        final boolean omitAuditFields);
 }

--- a/stroom-importexport/stroom-importexport-impl/src/main/java/stroom/importexport/impl/ImportExportSerializerImpl.java
+++ b/stroom-importexport/stroom-importexport-impl/src/main/java/stroom/importexport/impl/ImportExportSerializerImpl.java
@@ -23,6 +23,7 @@ import stroom.explorer.api.ExplorerService;
 import stroom.explorer.shared.ExplorerConstants;
 import stroom.explorer.shared.ExplorerNode;
 import stroom.explorer.shared.PermissionInheritance;
+import stroom.importexport.api.ExportSummary;
 import stroom.importexport.api.ImportExportActionHandler;
 import stroom.importexport.api.ImportExportDocumentEventLog;
 import stroom.importexport.api.NonExplorerDocRefProvider;
@@ -464,25 +465,34 @@ class ImportExportSerializerImpl implements ImportExportSerializer {
 
     /**
      * EXPORT
+     * @return
      */
     @Override
-    public void write(final Path dir, final Set<DocRef> docRefs, final boolean omitAuditFields,
-                      final List<Message> messageList) {
+    public ExportSummary write(final Path dir,
+                               final Set<DocRef> docRefs,
+                               final boolean omitAuditFields) {
         // Create a set of all entities that we are going to try and export.
-        Set<DocRef> expandedDocRefs = expandDocRefSet(docRefs);
+        final Set<DocRef> expandedDocRefs = expandDocRefSet(docRefs);
 
         if (expandedDocRefs.size() == 0) {
             throw new EntityServiceException("No documents were found that could be exported");
         }
 
+        final ExportSummary exportSummary = new ExportSummary();
+        final List<Message> messageList = new ArrayList<>();
         for (final DocRef docRef : expandedDocRefs) {
             try {
+                LOGGER.debug("Exporting {} to {}, omitAuditFields: {}", docRef, dir, omitAuditFields);
                 performExport(dir, docRef, omitAuditFields, messageList);
+                exportSummary.addSuccess(docRef.getType());
             } catch (final IOException | RuntimeException e) {
                 messageList.add(new Message(Severity.ERROR,
                         "Error created while exporting (" + docRef.toString() + ") : " + e.getMessage()));
+                exportSummary.addFailure(docRef.getType());
             }
         }
+        exportSummary.setMessages(messageList);
+        return exportSummary;
     }
 
     private ExplorerNode getOrCreateParentFolder(ExplorerNode parent,
@@ -726,4 +736,5 @@ class ImportExportSerializerImpl implements ImportExportSerializer {
         }
         return "";
     }
+
 }

--- a/stroom-importexport/stroom-importexport-impl/src/main/java/stroom/importexport/impl/ImportExportService.java
+++ b/stroom-importexport/stroom-importexport-impl/src/main/java/stroom/importexport/impl/ImportExportService.java
@@ -17,6 +17,7 @@
 package stroom.importexport.impl;
 
 import stroom.docref.DocRef;
+import stroom.importexport.api.ExportSummary;
 import stroom.importexport.shared.ImportSettings;
 import stroom.importexport.shared.ImportState;
 import stroom.util.shared.Message;
@@ -39,8 +40,8 @@ public interface ImportExportService {
      * <p>
      * Also in the zip file output content that can be exploded and stored in
      * source control. Used for tracking changes with XSLT and feeds.
+     * @return
      */
-    void exportConfig(Set<DocRef> docRefs,
-                      Path data,
-                      List<Message> messageList);
+    ExportSummary exportConfig(Set<DocRef> docRefs,
+                               Path data);
 }

--- a/stroom-importexport/stroom-importexport-impl/src/main/java/stroom/importexport/impl/ImportExportServiceImpl.java
+++ b/stroom-importexport/stroom-importexport-impl/src/main/java/stroom/importexport/impl/ImportExportServiceImpl.java
@@ -17,11 +17,11 @@
 package stroom.importexport.impl;
 
 import stroom.docref.DocRef;
+import stroom.importexport.api.ExportSummary;
 import stroom.importexport.shared.ImportSettings;
 import stroom.importexport.shared.ImportState;
 import stroom.util.io.FileUtil;
 import stroom.util.io.TempDirProvider;
-import stroom.util.shared.Message;
 import stroom.util.zip.ZipUtil;
 
 import java.io.IOException;
@@ -77,19 +77,23 @@ public class ImportExportServiceImpl implements ImportExportService {
 
     /**
      * Export the selected folder data.
+     * @return
      */
     @Override
-    public void exportConfig(final Set<DocRef> docRefs, final Path zipFile,
-                             final List<Message> messageList) {
+    public ExportSummary exportConfig(final Set<DocRef> docRefs,
+                                      final Path zipFile) {
         final Path explodeDir = workingZipDir(zipFile);
         try {
             Files.createDirectories(explodeDir);
 
             // Serialize the config in a human readable tree structure.
-            importExportSerializer.write(explodeDir, docRefs, true, messageList);
+            final ExportSummary exportSummary = importExportSerializer.write(
+                    explodeDir, docRefs, true);
 
             // Now zip the dir.
             ZipUtil.zip(zipFile, explodeDir);
+
+            return exportSummary;
 
         } catch (final IOException e) {
             throw new RuntimeException(e.getMessage(), e);

--- a/unreleased_changes/20230117_111631_086__0.md
+++ b/unreleased_changes/20230117_111631_086__0.md
@@ -1,0 +1,19 @@
+* Add info logging to the export all api resource. Outputs the number of docs export along with counts by type.
+
+
+```sh
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Issue **123** : Fix bug with an associated GitHub issue in this repository
+#
+# * Issue **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository
+#
+# * Fix bug with no associated GitHub issue.
+```


### PR DESCRIPTION
Add info logging to export all api resource

```
INFO  2023-01-17T11:10:08.992Z dw-98 - GET /api/export/v1/ s.i.i.ContentServiceImpl       Exporting all config to temp file /tmp/stroom/v7/node1a/resources/0StroomConfig.zip 
INFO  2023-01-17T11:10:10.538Z dw-98 - GET /api/export/v1/ s.i.i.ContentServiceImpl       Exported 433 documents (0 failures) using temp file /tmp/stroom/v7/node1a/resources/0StroomConfig.zip, counts by type:
| Type               | Success | Failed |
|--------------------|---------|--------|
| Dashboard          |      51 |      0 |
| Dictionary         |       4 |      0 |
| Feed               |      72 |      0 |
| Index              |       5 |      0 |
| KafkaConfig        |       2 |      0 |
| Pipeline           |      88 |      0 |
| ProcessorFilter    |      51 |      0 |
| ReceiveDataRuleSet |       1 |      0 |
| Script             |      25 |      0 |
| SolrIndex          |       1 |      0 |
| StatisticStore     |      20 |      0 |
| StroomStatsStore   |      19 |      0 |
| TextConverter      |      12 |      0 |
| Visualisation      |      17 |      0 |
| XMLSchema          |      18 |      0 |
| XSLT               |      47 |      0 |
messages:
| Severity | Message |
|----------|---------|
| ERROR    | hello   |
| WARN     | hello2  |
```