### PR TITLE
Fix DependenciesPresenter GWT compile errors

### DIFF
--- a/stroom-core-client-widget/src/main/java/stroom/widget/menu/client/presenter/MenuItemCell.java
+++ b/stroom-core-client-widget/src/main/java/stroom/widget/menu/client/presenter/MenuItemCell.java
@@ -17,7 +17,6 @@
 package stroom.widget.menu.client.presenter;
 
 import stroom.svg.client.Icon;
-import stroom.widget.menu.client.presenter.MenuItemCell.SeparatorAppearance.Template;
 
 import com.google.gwt.cell.client.AbstractCell;
 import com.google.gwt.cell.client.ValueUpdater;

--- a/stroom-core-client-widget/src/main/java/stroom/widget/popup/client/view/SimplePopup.java
+++ b/stroom-core-client-widget/src/main/java/stroom/widget/popup/client/view/SimplePopup.java
@@ -76,6 +76,11 @@ public class SimplePopup extends AbstractPopupPanel {
     }
 
     @Override
+    protected void onEscapeKeyPressed() {
+        hide(false);
+    }
+
+    @Override
     public void setContent(final Widget widget) {
         content.setWidget(widget);
     }


### PR DESCRIPTION
Resolves compile issues with #3217. Due to the use of `ActionMenuPresenter`, which isn't available in the correct module.