### PR TITLE
Backport proxy `/stroom/datafeed` endpoint alias

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -83,4 +83,4 @@ jobs:
           -x gwtCompile
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.idea/runConfigurations/Stroom_Proxy.xml
+++ b/.idea/runConfigurations/Stroom_Proxy.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Stroom Proxy" type="Application" factoryName="Application">
-    <option name="ALTERNATIVE_JRE_PATH" value="15" />
+    <option name="ALTERNATIVE_JRE_PATH" value="corretto-15" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <envs>
       <env name="STROOM_RESOURCES_REPO_DIR" value="$PROJECT_DIR$/../stroom-resources" />

--- a/stroom-app/src/main/java/stroom/app/guice/AppModule.java
+++ b/stroom-app/src/main/java/stroom/app/guice/AppModule.java
@@ -2,6 +2,7 @@ package stroom.app.guice;
 
 import stroom.app.uri.UriFactoryModule;
 import stroom.cluster.impl.ClusterModule;
+import stroom.dropwizard.common.DropwizardModule;
 import stroom.dropwizard.common.FilteredHealthCheckServlet;
 import stroom.dropwizard.common.LogLevelInspector;
 import stroom.index.impl.IndexShardWriterExecutorProvider;
@@ -21,6 +22,7 @@ public class AppModule extends AbstractModule {
     @Override
     protected void configure() {
 
+        install(new DropwizardModule());
         install(new UriFactoryModule());
         install(new CoreModule());
         install(new LifecycleServiceModule());

--- a/stroom-app/src/main/resources/ui/noauth/swagger/stroom.json
+++ b/stroom-app/src/main/resources/ui/noauth/swagger/stroom.json
@@ -12954,7 +12954,10 @@
       "PropertyPath" : {
         "type" : "object",
         "properties" : {
-          "parts" : {
+          "leafPart" : {
+            "type" : "string"
+          },
+          "parentParts" : {
             "type" : "array",
             "items" : {
               "type" : "string"

--- a/stroom-app/src/main/resources/ui/noauth/swagger/stroom.yaml
+++ b/stroom-app/src/main/resources/ui/noauth/swagger/stroom.yaml
@@ -9138,7 +9138,9 @@ components:
     PropertyPath:
       type: object
       properties:
-        parts:
+        leafPart:
+          type: string
+        parentParts:
           type: array
           items:
             type: string

--- a/stroom-core/src/main/java/stroom/core/servlet/StatusServlet.java
+++ b/stroom-core/src/main/java/stroom/core/servlet/StatusServlet.java
@@ -19,6 +19,7 @@ package stroom.core.servlet;
 
 import stroom.util.shared.BuildInfo;
 import stroom.util.shared.IsServlet;
+import stroom.util.shared.ResourcePaths;
 import stroom.util.shared.Unauthenticated;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -44,7 +45,8 @@ public class StatusServlet extends HttpServlet implements IsServlet {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StatusServlet.class);
 
-    private static final Set<String> PATH_SPECS = Set.of("/status");
+    private static final Set<String> PATH_SPECS = Set.of(
+            ResourcePaths.addUnauthenticatedPrefix("/status"));
 
     private final Provider<BuildInfo> buildInfoProvider;
 

--- a/stroom-core/src/main/java/stroom/core/servlet/SwaggerUiServlet.java
+++ b/stroom-core/src/main/java/stroom/core/servlet/SwaggerUiServlet.java
@@ -33,7 +33,8 @@ public class SwaggerUiServlet extends HttpServlet implements IsServlet {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SwaggerUiServlet.class);
 
-    private static final Set<String> PATH_SPECS = Set.of("/swagger-ui");
+    private static final Set<String> PATH_SPECS = Set.of(
+            ResourcePaths.addUnauthenticatedPrefix("/swagger-ui"));
 
     private static final String TITLE = "@TITLE@";
     private static final String SWAGGER_SPEC_URL_TAG = "@SWAGGER_SPEC_URL@";

--- a/stroom-data/stroom-data-store-impl-fs/src/main/java/stroom/data/store/impl/fs/EchoServlet.java
+++ b/stroom-data/stroom-data-store-impl-fs/src/main/java/stroom/data/store/impl/fs/EchoServlet.java
@@ -18,6 +18,7 @@ package stroom.data.store.impl.fs;
 
 import stroom.util.io.StreamUtil;
 import stroom.util.shared.IsServlet;
+import stroom.util.shared.ResourcePaths;
 import stroom.util.shared.Unauthenticated;
 
 import java.io.IOException;
@@ -32,7 +33,8 @@ public class EchoServlet extends HttpServlet implements IsServlet {
 
     private static final long serialVersionUID = -2569496543022536282L;
 
-    private static final Set<String> PATH_SPECS = Set.of("/echo");
+    private static final Set<String> PATH_SPECS = Set.of(
+            ResourcePaths.addUnauthenticatedPrefix("/echo"));
 
     @Override
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {

--- a/stroom-dropwizard-common/src/main/java/stroom/dropwizard/common/DropwizardModule.java
+++ b/stroom-dropwizard-common/src/main/java/stroom/dropwizard/common/DropwizardModule.java
@@ -1,0 +1,13 @@
+package stroom.dropwizard.common;
+
+import stroom.util.shared.ServletAuthenticationChecker;
+
+import com.google.inject.AbstractModule;
+
+public class DropwizardModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        bind(ServletAuthenticationChecker.class).to(Servlets.class);
+    }
+}

--- a/stroom-proxy/stroom-proxy-app/src/main/java/stroom/proxy/app/guice/ProxyModule.java
+++ b/stroom-proxy/stroom-proxy-app/src/main/java/stroom/proxy/app/guice/ProxyModule.java
@@ -12,6 +12,7 @@ import stroom.docstore.impl.Persistence;
 import stroom.docstore.impl.Serialiser2FactoryImpl;
 import stroom.docstore.impl.StoreFactoryImpl;
 import stroom.docstore.impl.fs.FSPersistence;
+import stroom.dropwizard.common.DropwizardModule;
 import stroom.dropwizard.common.FilteredHealthCheckServlet;
 import stroom.dropwizard.common.LogLevelInspector;
 import stroom.dropwizard.common.PermissionExceptionMapper;
@@ -117,6 +118,7 @@ public class ProxyModule extends AbstractModule {
         bind(HealthCheckRegistry.class).toInstance(environment.healthChecks());
 
         install(new ProxyConfigModule(proxyConfigHolder));
+        install(new DropwizardModule());
         install(new MockCollectionModule());
 
         install(new DictionaryModule());

--- a/stroom-proxy/stroom-proxy-app/src/main/java/stroom/proxy/app/servlet/ProxyStatusServlet.java
+++ b/stroom-proxy/stroom-proxy-app/src/main/java/stroom/proxy/app/servlet/ProxyStatusServlet.java
@@ -2,6 +2,7 @@ package stroom.proxy.app.servlet;
 
 import stroom.util.shared.BuildInfo;
 import stroom.util.shared.IsServlet;
+import stroom.util.shared.ResourcePaths;
 import stroom.util.shared.Unauthenticated;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -27,7 +28,8 @@ public class ProxyStatusServlet extends HttpServlet implements IsServlet {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ProxyStatusServlet.class);
 
-    private static final Set<String> PATH_SPECS = Set.of("/status");
+    private static final Set<String> PATH_SPECS = Set.of(
+            ResourcePaths.addUnauthenticatedPrefix("/status"));
 
     private final Provider<BuildInfo> buildInfoProvider;
 

--- a/stroom-receive/stroom-receive-common/src/main/java/stroom/receive/common/DebugServlet.java
+++ b/stroom-receive/stroom-receive-common/src/main/java/stroom/receive/common/DebugServlet.java
@@ -17,6 +17,7 @@
 package stroom.receive.common;
 
 import stroom.util.shared.IsServlet;
+import stroom.util.shared.ResourcePaths;
 import stroom.util.shared.Unauthenticated;
 import stroom.util.web.DebugServletUtil;
 
@@ -32,7 +33,8 @@ public class DebugServlet extends HttpServlet implements IsServlet {
 
     private static final long serialVersionUID = 5785836851738107760L;
 
-    private static final Set<String> PATH_SPECS = Set.of("/debug");
+    private static final Set<String> PATH_SPECS = Set.of(
+            ResourcePaths.addUnauthenticatedPrefix("/debug"));
 
     @Override
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {

--- a/stroom-receive/stroom-receive-common/src/main/java/stroom/receive/common/ReceiveDataServlet.java
+++ b/stroom-receive/stroom-receive-common/src/main/java/stroom/receive/common/ReceiveDataServlet.java
@@ -17,6 +17,7 @@
 package stroom.receive.common;
 
 import stroom.util.shared.IsServlet;
+import stroom.util.shared.ResourcePaths;
 import stroom.util.shared.Unauthenticated;
 
 import org.slf4j.Logger;
@@ -43,7 +44,16 @@ public class ReceiveDataServlet extends HttpServlet implements IsServlet {
     private static final Logger LOGGER = LoggerFactory.getLogger(ReceiveDataServlet.class);
     private static final long serialVersionUID = 1L;
 
-    private static final Set<String> PATH_SPECS = Set.of("/datafeed", "/datafeed/*");
+    public static final String DATA_FEED_PATH_PART = "/datafeed";
+
+    // AWS ELB/ALB can't map paths so rather than add nginx or similar into the mix to map paths,
+    // have a pair of aliases without 'noauth' in them.
+    // This is somewhat inconsistent with our other servlets so far from ideal.
+    private static final Set<String> PATH_SPECS = Set.of(
+            ResourcePaths.addUnauthenticatedPrefix(DATA_FEED_PATH_PART),
+            ResourcePaths.addUnauthenticatedPrefix(DATA_FEED_PATH_PART, "/*"),
+            DATA_FEED_PATH_PART,
+            DATA_FEED_PATH_PART + "/*");
 
     private final Provider<RequestHandler> requestHandlerProvider;
 

--- a/stroom-receive/stroom-receive-common/src/main/java/stroom/receive/common/RemoteFeedServiceRPC.java
+++ b/stroom-receive/stroom-receive-common/src/main/java/stroom/receive/common/RemoteFeedServiceRPC.java
@@ -3,6 +3,7 @@ package stroom.receive.common;
 import stroom.proxy.feed.remote.GetFeedStatusRequest;
 import stroom.proxy.feed.remote.GetFeedStatusResponse;
 import stroom.util.shared.IsServlet;
+import stroom.util.shared.ResourcePaths;
 import stroom.util.shared.Unauthenticated;
 
 import com.caucho.hessian.server.HessianServlet;
@@ -13,7 +14,8 @@ import javax.inject.Inject;
 @Unauthenticated
 public class RemoteFeedServiceRPC extends HessianServlet implements IsServlet {
 
-    private static final Set<String> PATH_SPECS = Set.of("/remoting/remotefeedservice.rpc");
+    private static final Set<String> PATH_SPECS = Set.of(
+            ResourcePaths.addUnauthenticatedPrefix("/remoting/remotefeedservice.rpc"));
 
     private final FeedStatusService feedStatusService;
 

--- a/stroom-security/stroom-security-impl/src/main/java/stroom/security/impl/SecurityFilter.java
+++ b/stroom-security/stroom-security-impl/src/main/java/stroom/security/impl/SecurityFilter.java
@@ -17,7 +17,6 @@
 package stroom.security.impl;
 
 import stroom.config.common.UriFactory;
-import stroom.security.api.ProcessingUserIdentityProvider;
 import stroom.security.api.SecurityContext;
 import stroom.security.api.UserIdentity;
 import stroom.security.impl.exception.AuthenticationException;
@@ -28,6 +27,7 @@ import stroom.util.logging.LambdaLoggerFactory;
 import stroom.util.logging.LogUtil;
 import stroom.util.net.UrlUtils;
 import stroom.util.shared.ResourcePaths;
+import stroom.util.shared.ServletAuthenticationChecker;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,7 +67,7 @@ class SecurityFilter implements Filter {
     private final UriFactory uriFactory;
     private final SecurityContext securityContext;
     private final OpenIdManager openIdManager;
-    private final ProcessingUserIdentityProvider processingUserIdentityProvider;
+    private final ServletAuthenticationChecker servletAuthenticationChecker;
 
     @Inject
     SecurityFilter(
@@ -75,12 +75,12 @@ class SecurityFilter implements Filter {
             final UriFactory uriFactory,
             final SecurityContext securityContext,
             final OpenIdManager openIdManager,
-            final ProcessingUserIdentityProvider processingUserIdentityProvider) {
+            final ServletAuthenticationChecker servletAuthenticationChecker) {
         this.authenticationConfigProvider = authenticationConfigProvider;
         this.uriFactory = uriFactory;
         this.securityContext = securityContext;
         this.openIdManager = openIdManager;
-        this.processingUserIdentityProvider = processingUserIdentityProvider;
+        this.servletAuthenticationChecker = servletAuthenticationChecker;
     }
 
     @Override
@@ -156,10 +156,10 @@ class SecurityFilter implements Filter {
                 if (userIdentity.isPresent()) {
                     continueAsUser(request, response, chain, userIdentity.get());
 
-                } else if (shouldBypassAuthentication(fullPath)) {
-                    // Some paths don't need authentication (they contain `/noauth/`.
-                    // If that is the case then proceed as proc user.
-                    authenticateAsProcUser(request, response, chain);
+                } else if (shouldBypassAuthentication(fullPath, servletPath)) {
+                    // Some paths don't need authentication. If that is the case then proceed as proc user.
+                    securityContext.asProcessingUser(() ->
+                            process(request, response, chain));
 
                 } else if (isApiRequest(servletPath)) {
                     // If we couldn't login with a token or couldn't get a token then error as this is an API call
@@ -169,7 +169,6 @@ class SecurityFilter implements Filter {
 
                 } else if (request.getRequestURI().equals("/")) {
                     // UI request, so instigate an OpenID authentication flow
-                    // like the good relying party we are.
                     try {
                         final String postAuthRedirectUri = getPostAuthRedirectUri(request);
 
@@ -228,8 +227,14 @@ class SecurityFilter implements Filter {
         return servletPath.startsWith(ResourcePaths.API_ROOT_PATH);
     }
 
-    private boolean shouldBypassAuthentication(final String fullPath) {
-        return fullPath.contains(ResourcePaths.NO_AUTH + "/");
+    private boolean shouldBypassAuthentication(final String fullPath, final String servletPath) {
+        if (servletPath == null) {
+            return false;
+        } else if (fullPath.contains(ResourcePaths.NO_AUTH + "/")) {
+            return true;
+        } else {
+            return servletAuthenticationChecker.isUnauthenticatedPath(servletPath);
+        }
     }
 
     private void authenticateAsAdmin(final HttpServletRequest request,
@@ -238,12 +243,6 @@ class SecurityFilter implements Filter {
 
         bypassAuthentication(request, response, chain, UserIdentitySessionUtil.requestHasSessionCookie(request),
                 securityContext.createIdentity(User.ADMIN_USER_NAME));
-    }
-
-    private void authenticateAsProcUser(final HttpServletRequest request,
-                                        final HttpServletResponse response,
-                                        final FilterChain chain) throws IOException, ServletException {
-        bypassAuthentication(request, response, chain, false, processingUserIdentityProvider.get());
     }
 
     private void bypassAuthentication(final HttpServletRequest request,
@@ -274,6 +273,16 @@ class SecurityFilter implements Filter {
             } finally {
                 CurrentUserState.pop();
             }
+        }
+    }
+
+    private void process(final HttpServletRequest request,
+                         final HttpServletResponse response,
+                         final FilterChain chain) {
+        try {
+            chain.doFilter(request, response);
+        } catch (final IOException | ServletException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/stroom-ui/src/api/stroom.ts
+++ b/stroom-ui/src/api/stroom.ts
@@ -2162,7 +2162,8 @@ export interface Prop {
 }
 
 export interface PropertyPath {
-  parts?: string[];
+  leafPart?: string;
+  parentParts?: string[];
 }
 
 /**

--- a/stroom-util-shared/src/main/java/stroom/util/shared/ResourcePaths.java
+++ b/stroom-util-shared/src/main/java/stroom/util/shared/ResourcePaths.java
@@ -54,6 +54,16 @@ public interface ResourcePaths {
     String V3 = "/v3";
 
 
+    static String addUnauthenticatedPrefix(final String... parts) {
+        return new Builder()
+                .addPathPart(NO_AUTH)
+                .addPathParts(parts)
+                .build();
+    }
+
+    /**
+     * Creates a full path (including root) to an unauthenticated servlet ending in parts
+     */
     static String buildUnauthenticatedServletPath(final String... parts) {
         return new Builder()
                 .addPathPart(ROOT_PATH)
@@ -62,7 +72,10 @@ public interface ResourcePaths {
                 .build();
     }
 
-    static String buildAuthenticatedServletPath(final String... parts) {
+    /**
+     * Creates a full path (including root) to a servlet ending in parts
+     */
+    static String buildServletPath(final String... parts) {
         return new Builder()
                 .addPathPart(ROOT_PATH)
                 .addPathParts(parts)

--- a/stroom-util-shared/src/main/java/stroom/util/shared/ServletAuthenticationChecker.java
+++ b/stroom-util-shared/src/main/java/stroom/util/shared/ServletAuthenticationChecker.java
@@ -1,0 +1,10 @@
+package stroom.util.shared;
+
+public interface ServletAuthenticationChecker {
+
+    /**
+     * @param servletPath The servlet path for the servlet being requested
+     * @return True if servletPath matches a path spec for a servlet marked with {@link Unauthenticated}
+     */
+    boolean isUnauthenticatedPath(final String servletPath);
+}

--- a/unreleased_changes/20230509_180658_676__3203.md
+++ b/unreleased_changes/20230509_180658_676__3203.md
@@ -1,0 +1,24 @@
+* Issue **#3203** : Allow unauthenticated servlets to have paths without `/noauth/` in. Add path specs `/stroom/datafeed` and `/stroom/datafeed/*` for the data receipt servlet in addition to the existing `/noauth/` ones.
+
+
+```sh
+# ********************************************************************************
+# Issue title: Change noauth path of URLs
+# Issue link:  https://github.com/gchq/stroom/issues/3203
+# ********************************************************************************
+
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Issue **123** : Fix bug with an associated GitHub issue in this repository
+#
+# * Issue **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository
+#
+# * Fix bug with no associated GitHub issue.
+```


### PR DESCRIPTION
#3203 Added a `/stroom/datafeed` endpoint alias for `/stroom/noauth/datafeed`. This is useful when replacing v5 proxies with v7, which expect the `/stroom/datafeed` path to exist when forwarding.