### PR TITLE
PR for #3595 - `data()` links not working from a directly linked dashboard

### DIFF
--- a/stroom-core-client/src/main/java/stroom/hyperlink/client/HyperlinkEventHandlerImpl.java
+++ b/stroom-core-client/src/main/java/stroom/hyperlink/client/HyperlinkEventHandlerImpl.java
@@ -69,9 +69,14 @@ public class HyperlinkEventHandlerImpl extends HandlerContainerImpl implements H
         registerHandler(eventBus.addHandler(HyperlinkEvent.getType(), this));
     }
 
+    private static native void nativeConsoleLog(String s) /*-{
+        $wnd.console.log(s);
+    }-*/;
+
     @Override
     public void onLink(final HyperlinkEvent event) {
         final Hyperlink hyperlink = event.getHyperlink();
+        nativeConsoleLog("HyperlinkEvent: " + hyperlink.getHref());
 
         String href = hyperlink.getHref();
 //        if (namedUrls != null) {

--- a/stroom-dashboard-gwt/src/main/java/stroom/dashboard/client/gin/DashboardAppModule.java
+++ b/stroom-dashboard-gwt/src/main/java/stroom/dashboard/client/gin/DashboardAppModule.java
@@ -32,6 +32,7 @@ import stroom.data.client.presenter.CharacterRangeSelectionPresenter;
 import stroom.data.client.presenter.CharacterRangeSelectionPresenter.CharacterRangeSelectionView;
 import stroom.data.client.presenter.ClassificationWrapperPresenter;
 import stroom.data.client.presenter.ClassificationWrapperPresenter.ClassificationWrapperView;
+import stroom.data.client.presenter.DataDisplaySupport;
 import stroom.data.client.presenter.DataPresenter;
 import stroom.data.client.presenter.DataPresenter.DataView;
 import stroom.data.client.presenter.DataPreviewTabPresenter;
@@ -56,6 +57,7 @@ import stroom.data.client.view.ItemSelectionViewImpl;
 import stroom.data.client.view.SourceTabViewImpl;
 import stroom.data.client.view.SourceViewImpl;
 import stroom.data.client.view.TextViewImpl;
+import stroom.editor.client.presenter.DelegatingAceCompleter;
 import stroom.editor.client.presenter.EditorPresenter;
 import stroom.editor.client.presenter.EditorView;
 import stroom.editor.client.view.EditorViewImpl;
@@ -94,6 +96,8 @@ public class DashboardAppModule extends AbstractPresenterModule {
         bind(RootPresenter.class).asEagerSingleton();
         bind(PlaceManager.class).to(InactivePlaceManager.class).in(Singleton.class);
         bind(UrlParameters.class).in(Singleton.class);
+        bind(DelegatingAceCompleter.class).asEagerSingleton();
+        bind(DataDisplaySupport.class).asEagerSingleton();
 
         // Presenters
         bindPresenter(CorePresenter.class, CoreView.class, CoreViewImpl.class, CoreProxy.class);
@@ -106,6 +110,7 @@ public class DashboardAppModule extends AbstractPresenterModule {
 
         bindSharedView(DropDownPresenter.DropDrownView.class, DropDownViewImpl.class);
         bindSharedView(DropDownTreePresenter.DropDownTreeView.class, DropDownTreeViewImpl.class);
+
 
         bindPresenterWidget(
                 EntityTreePresenter.class,

--- a/unreleased_changes/20230712_090135_261__3595.md
+++ b/unreleased_changes/20230712_090135_261__3595.md
@@ -1,0 +1,24 @@
+* Issue **#3595** : Fix `data()` links when the dashboard is directly linked. Only works for `displayType` of `dialog`, not `tab` as there are no tabs in a direct linked dashboard.
+
+
+```sh
+# ********************************************************************************
+# Issue title: `data()` links not working from a directly linked dashboard
+# Issue link:  https://github.com/gchq/stroom/issues/3595
+# ********************************************************************************
+
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Issue **123** : Fix bug with an associated GitHub issue in this repository
+#
+# * Issue **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository
+#
+# * Fix bug with no associated GitHub issue.
+```


### PR DESCRIPTION
Fixes #3595