### PR TITLE
Fix XML header being written multiple times with RolledFileAppender and compression enabled

### DIFF
--- a/stroom-pipeline/src/main/java/stroom/pipeline/destination/RollingDestination.java
+++ b/stroom-pipeline/src/main/java/stroom/pipeline/destination/RollingDestination.java
@@ -109,7 +109,7 @@ public abstract class RollingDestination implements Destination {
 
         // If we haven't written yet then create the output stream and
         // write a header if we have one.
-        if (header != null && header.length > 0 && outputStream != null && outputStream.getCount() == 0) {
+        if (header != null && header.length > 0 && outputStream != null && !outputStream.getHasBytesWritten()) {
             // Write the header.
             write(header);
         }

--- a/stroom-util/src/main/java/stroom/util/io/ByteCountOutputStream.java
+++ b/stroom-util/src/main/java/stroom/util/io/ByteCountOutputStream.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public class ByteCountOutputStream extends WrappedOutputStream {
 
     private final AtomicLong count = new AtomicLong();
+    private boolean hasBytesWritten = false;
 
     public ByteCountOutputStream(final OutputStream outputStream) {
         super(outputStream);
@@ -43,10 +44,21 @@ public class ByteCountOutputStream extends WrappedOutputStream {
     @Override
     public void write(final byte[] b, final int off, final int len) throws IOException {
         count.addAndGet(len);
+
+        // If any bytes are to be written, set the `hasBytesWritten` flag to `true`.
+        // This allows the caller to determine whether the stream header has already been written.
+        if (len > 0) {
+            hasBytesWritten = true;
+        }
+
         super.write(b, off, len);
     }
 
     public long getCount() {
         return count.get();
+    }
+
+    public boolean getHasBytesWritten() {
+        return hasBytesWritten;
     }
 }

--- a/unreleased_changes/20230809_133740_304__3683.md
+++ b/unreleased_changes/20230809_133740_304__3683.md
@@ -1,0 +1,24 @@
+* Issue **#3683** : Fix XML header being written multiple times with RolledFileAppender and compression enabled.
+
+
+```sh
+# ********************************************************************************
+# Issue title: RolledFileAppender produces invalid XML
+# Issue link:  https://github.com/gchq/stroom/issues/3683
+# ********************************************************************************
+
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Issue **123** : Fix bug with an associated GitHub issue in this repository
+#
+# * Issue **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository
+#
+# * Fix bug with no associated GitHub issue.
+```


### PR DESCRIPTION
This issue is caused by `GZIPOutputStream::getBytesWritten()` returning `0` until the stream is flushed.

Since we want to roll the GZIP stream based on the compressed size, we can't rely on the `getCount()` of `ByteCountOutputStream`, which counts the raw (uncompressed) bytes written to the wrapped stream.

The crux of the issue is that [this line](https://github.com/gchq/stroom/compare/master...p-kimberley:gh-3683?expand=1#diff-1a17ddf65e3d509ca79203b9ef72749ddb0dae29662b142652f35d4257b44b16L112) is testing `getCount()` of the stream. All we need to know is whether any data has been written (and if not, to write out the header).

We can accomplish this by using a simple `boolean` flag that tracks whether any data has been written to the stream.