### PR TITLE
PR for #3846 - Non-matching entries when entering Quick Filter are in too light a font when in light mode

### DIFF
--- a/stroom-app/src/main/resources/ui/css/celltable/ExplorerTree.css
+++ b/stroom-app/src/main/resources/ui/css/celltable/ExplorerTree.css
@@ -71,7 +71,6 @@
 }
 
 .explorerCell-filter-match .explorerCell-text {
-
 }
 
 .explorerCell-filter-no-match .explorerCell-text {

--- a/stroom-app/src/main/resources/ui/css/theme-root.css
+++ b/stroom-app/src/main/resources/ui/css/theme-root.css
@@ -229,7 +229,7 @@
     --navigation__title__background-color: var(--icon-colour__blue);
     --navigation__text-color: var(--text-color);
     --navigation__text-color--selected: var(--row__text-color--selected);
-    --navigation__text-color--no-match: #a9a9a9;
+    --navigation__text-color--no-match: #767676;
 
     /* Specific */
     --header__icon-color: #2185d0;

--- a/unreleased_changes/20231016_142324_125__3846.md
+++ b/unreleased_changes/20231016_142324_125__3846.md
@@ -1,0 +1,24 @@
+* Issue **#3846** : Increase contrast ratio of non-matches in filtered explorer tree when in light mode.
+
+
+```sh
+# ********************************************************************************
+# Issue title: Non-matching entries when entering Quick Filter are in too light a font when in light mode
+# Issue link:  https://github.com/gchq/stroom/issues/3846
+# ********************************************************************************
+
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Issue **123** : Fix bug with an associated GitHub issue in this repository
+#
+# * Issue **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository
+#
+# * Fix bug with no associated GitHub issue.
+```


### PR DESCRIPTION
Fixes #3846