### PR TITLE
PR for #3883 - Stroom core_test stack not giving `administrator` perms to `admin`

### DIFF
--- a/stroom-security/stroom-security-impl/src/main/java/stroom/security/impl/AuthenticationService.java
+++ b/stroom-security/stroom-security-impl/src/main/java/stroom/security/impl/AuthenticationService.java
@@ -118,7 +118,9 @@ public class AuthenticationService {
 
         return userDao.tryCreate(user, createdUser -> {
             LOGGER.info("Created new stroom_user record, type: '{}', subjectId: '{}', userUuid: '{}'",
-                    (isGroup ? "group" : "user"),
+                    (isGroup
+                            ? "group"
+                            : "user"),
                     createdUser.getSubjectId(),
                     createdUser.getUuid());
         });
@@ -131,7 +133,8 @@ public class AuthenticationService {
             optUser = userDao.getBySubjectId(subjectId, false);
             if (optUser.isEmpty()
                     && User.ADMIN_SUBJECT_ID.equals(subjectId)
-                    && IdpType.INTERNAL_IDP.equals(openIdConfigProvider.get().getIdentityProviderType())) {
+                    && (IdpType.INTERNAL_IDP.equals(openIdConfigProvider.get().getIdentityProviderType())
+                    || IdpType.TEST_CREDENTIALS.equals(openIdConfigProvider.get().getIdentityProviderType()))) {
 
                 // TODO @AT Probably should be an explicit command to create this to avoid the accidental
                 //   running of stroom in UseInternal mode which then leaves admin/admin open
@@ -168,7 +171,8 @@ public class AuthenticationService {
 
                     // Creating the admin user so create its group too
                     if (User.ADMIN_SUBJECT_ID.equals(subjectId)
-                            && IdpType.INTERNAL_IDP.equals(openIdConfigProvider.get().getIdentityProviderType())) {
+                            && (IdpType.INTERNAL_IDP.equals(openIdConfigProvider.get().getIdentityProviderType())
+                            || IdpType.TEST_CREDENTIALS.equals(openIdConfigProvider.get().getIdentityProviderType()))) {
                         try {
                             User userGroup = createOrRefreshAdminUserGroup(ADMINISTRATORS_GROUP_SUBJECT_ID);
                             userDao.addUserToGroup(userRef.getUuid(), userGroup.getUuid());

--- a/unreleased_changes/20231027_162400_826__3883.md
+++ b/unreleased_changes/20231027_162400_826__3883.md
@@ -1,0 +1,24 @@
+* Issue **#3883** : Fix auto creation of `admin` user when an IDP type of TEST_CREDENTIALS is used.
+
+
+```sh
+# ********************************************************************************
+# Issue title: Stroom core_test stack not giving `administrator` perms to `admin`
+# Issue link:  https://github.com/gchq/stroom/issues/3883
+# ********************************************************************************
+
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Issue **123** : Fix bug with an associated GitHub issue in this repository
+#
+# * Issue **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository
+#
+# * Fix bug with no associated GitHub issue.
+```


### PR DESCRIPTION
Fixes #3883