### PR TITLE
PR for #4014 - Search with a `countGroups()` column causes hang

### DIFF
--- a/stroom-query/stroom-query-common/src/main/java/stroom/query/common/v2/LmdbDataStore.java
+++ b/stroom-query/stroom-query-common/src/main/java/stroom/query/common/v2/LmdbDataStore.java
@@ -1334,6 +1334,7 @@ public class LmdbDataStore implements DataStore {
                 long count = 0;
                 while (iterator.hasNext()
                         && !Thread.currentThread().isInterrupted()) {
+                    iterator.next();
                     // FIXME : NOTE THIS COUNT IS NOT FILTERED BY THE MAPPER.
                     count++;
                 }

--- a/stroom-query/stroom-query-language/src/main/java/stroom/query/language/functions/CountGroups.java
+++ b/stroom-query/stroom-query-language/src/main/java/stroom/query/language/functions/CountGroups.java
@@ -64,6 +64,10 @@ class CountGroups extends AbstractFunction implements AggregateFunction {
         return Type.LONG;
     }
 
+
+    // --------------------------------------------------------------------------------
+
+
     private static final class Gen extends AbstractNoChildGenerator {
 
         @Override

--- a/stroom-query/stroom-query-language/src/test/java/stroom/query/language/functions/AbstractFunctionTest.java
+++ b/stroom-query/stroom-query-language/src/test/java/stroom/query/language/functions/AbstractFunctionTest.java
@@ -131,6 +131,10 @@ public abstract class AbstractFunctionTest<T extends Function> {
                 ": " + val + "]";
     }
 
+
+    // --------------------------------------------------------------------------------
+
+
     static class TestCase {
 
         private final String testVariantName;
@@ -235,5 +239,4 @@ public abstract class AbstractFunctionTest<T extends Function> {
             return aggregateValues;
         }
     }
-
 }

--- a/unreleased_changes/20240117_124536_290__4014.md
+++ b/unreleased_changes/20240117_124536_290__4014.md
@@ -1,0 +1,24 @@
+* Issue **#4014** : Fix queries hanging dur to an infinite loop when using `countGroups()` expression function.
+
+
+```sh
+# ********************************************************************************
+# Issue title: Search with a `countGroups()` column causes hang
+# Issue link:  https://github.com/gchq/stroom/issues/4014
+# ********************************************************************************
+
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Issue **123** : Fix bug with an associated GitHub issue in this repository
+#
+# * Issue **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository
+#
+# * Fix bug with no associated GitHub issue.
+```


### PR DESCRIPTION
Fixes #4014