### PR TITLE
PR for #4270 - Typing `ct` into a query term value edit box opens a dialog

### DIFF
--- a/stroom-core-client-widget/src/main/java/stroom/widget/util/client/KeyBinding.java
+++ b/stroom-core-client-widget/src/main/java/stroom/widget/util/client/KeyBinding.java
@@ -194,12 +194,17 @@ public class KeyBinding {
         if (eventTarget != null) {
             if (Element.is(eventTarget)) {
                 final Element element = Element.as(eventTarget);
-                final String className = GwtNullSafe.string(element.getClassName());
+                final String tagName = element.getTagName();
+//                final String className = GwtNullSafe.string(element.getClassName());
+//                final String type = element.getAttribute("type");
+//                GWT.log("className: " + className + " tagName: " + element.getTagName() + " type: " + type);
                 // TODO this is really clunky. Need to create our own textbox and text area
                 //  components so that we can control the key events
-                shouldCheck = !className.contains("gwt-TextBox")
-                        && !className.contains("gwt-TextArea")
-                        && !className.contains("ace_text-input");
+                shouldCheck = !isTextBox(element, tagName)
+                        && !"TEXTAREA".equalsIgnoreCase(tagName);
+//                        && !className.contains("gwt-TextBox")
+//                        && !className.contains("gwt-TextArea")
+//                        && !className.contains("ace_text-input");
             } else {
                 shouldCheck = true;
             }
@@ -208,6 +213,16 @@ public class KeyBinding {
         }
 //        GWT.log("shouldCheck: " + shouldCheck);
         return shouldCheck;
+    }
+
+    private static boolean isTextBox(final Element element, final String tagName) {
+        return "INPUT".equalsIgnoreCase(tagName)
+                && GwtNullSafe.test(element.getAttribute("type"), type ->
+                "text".equalsIgnoreCase(type)
+                        || "password".equalsIgnoreCase(type)
+                        || "search".equalsIgnoreCase(type)
+                        || "number".equalsIgnoreCase(type)
+                        || "url".equalsIgnoreCase(type));
     }
 
     private static Action testKeyDownEvent(final NativeEvent e,

--- a/unreleased_changes/20240515_154322_833__4270.md
+++ b/unreleased_changes/20240515_154322_833__4270.md
@@ -1,0 +1,24 @@
+* Issue **#4270** : Fix key binds like `ct` triggering when in a query term value edit field.
+
+
+```sh
+# ********************************************************************************
+# Issue title: Typing `ct` into a query term value edit box opens a dialog
+# Issue link:  https://github.com/gchq/stroom/issues/4270
+# ********************************************************************************
+
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Issue **123** : Fix bug with an associated GitHub issue in this repository
+#
+# * Issue **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository
+#
+# * Fix bug with no associated GitHub issue.
+```


### PR DESCRIPTION
Fixes #4270