### PR TITLE
PR for #4424 - Current Tasks column doesn't line up on Jobs screen

### DIFF
--- a/stroom-core-client/src/main/java/stroom/job/client/presenter/JobNodeListPresenter.java
+++ b/stroom-core-client/src/main/java/stroom/job/client/presenter/JobNodeListPresenter.java
@@ -328,6 +328,7 @@ public class JobNodeListPresenter extends MyPresenterWidget<PagerView> implement
                         .rightAligned()
                         .build(),
                 DataGridUtil.headingBuilder("Current Tasks")
+                        .rightAligned()
                         .withToolTip("The number of the currently executing tasks on this node for this job")
                         .build(),
                 100);

--- a/unreleased_changes/20240904_140627_844__4424.md
+++ b/unreleased_changes/20240904_140627_844__4424.md
@@ -1,0 +1,24 @@
+* Issue **#4424** : Fix alignment of _Current Tasks_ heading on the Jobs screen.
+
+
+```sh
+# ********************************************************************************
+# Issue title: Current Tasks column doesn't line up on Jobs screen
+# Issue link:  https://github.com/gchq/stroom/issues/4424
+# ********************************************************************************
+
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Issue **123** : Fix bug with an associated GitHub issue in this repository
+#
+# * Issue **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository
+#
+# * Fix bug with no associated GitHub issue.
+```


### PR DESCRIPTION
Fixes #4424