### PR TITLE
PR for #4422 - "Edit Schedule" of "Manage Jobs" should not be displayed for Distributed Jobs

### DIFF
--- a/stroom-core-client/src/main/java/stroom/node/client/JobNodeListHelper.java
+++ b/stroom-core-client/src/main/java/stroom/node/client/JobNodeListHelper.java
@@ -362,19 +362,22 @@ public class JobNodeListHelper {
 
         final JobNode jobNode = GwtNullSafe.get(jobNodeAndInfo, JobNodeAndInfo::getJobNode);
         final String nodeName = GwtNullSafe.get(jobNodeAndInfo, JobNodeAndInfo::getNodeName);
-        final boolean canRunNow = GwtNullSafe.test(
+        final boolean isSchedulable = GwtNullSafe.test(
                 jobNodeAndInfo,
                 JobNodeAndInfo::getJobType,
                 type -> type == JobType.CRON || type == JobType.FREQUENCY);
 
-        final MenuBuilder builder = MenuBuilder.builder()
-                .withIconMenuItem(itemBuilder -> itemBuilder
-                        .icon(SvgImage.HISTORY)
-                        .text("Edit Schedule")
-                        .command(() ->
-                                showSchedule(jobNodeAndInfo)));
+        final MenuBuilder builder = MenuBuilder.builder();
 
-        if (canRunNow && isNodeEnabled(nodeName)) {
+        if (isSchedulable) {
+            builder.withIconMenuItem(itemBuilder -> itemBuilder
+                    .icon(SvgImage.HISTORY)
+                    .text("Edit Schedule")
+                    .command(() ->
+                            showSchedule(jobNodeAndInfo)));
+        }
+
+        if (isSchedulable && isNodeEnabled(nodeName)) {
             builder.withIconMenuItem(itemBuilder -> itemBuilder
                     .icon(SvgImage.PLAY)
                     .text("Run Job on '" + jobNode.getNodeName() + "' Now")

--- a/unreleased_changes/20240904_145126_422__4422.md
+++ b/unreleased_changes/20240904_145126_422__4422.md
@@ -1,0 +1,24 @@
+* Issue **#4422** : Don't show _Edit Schedule_ in actions menu on Jobs screen for Distributed jobs.
+
+
+```sh
+# ********************************************************************************
+# Issue title: "Edit Schedule" of "Manage Jobs" should not be displayed for Distributed Jobs
+# Issue link:  https://github.com/gchq/stroom/issues/4422
+# ********************************************************************************
+
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Issue **123** : Fix bug with an associated GitHub issue in this repository
+#
+# * Issue **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository
+#
+# * Fix bug with no associated GitHub issue.
+```


### PR DESCRIPTION
Fixes #4422