### PR TITLE
PR for #4837 - OIDC config GET uses httpClient, but token calls use jerseyClient

### DIFF
--- a/stroom-config/stroom-config-app/src/test/resources/stroom/config/app/expected.yaml
+++ b/stroom-config/stroom-config-app/src/test/resources/stroom/config/app/expected.yaml
@@ -794,7 +794,6 @@ appConfig:
         clientSecret: null
         expectedSignerPrefixes: []
         formTokenRequest: true
-        httpClient: null
         identityProviderType: "INTERNAL_IDP"
         issuer: null
         jwksUri: null

--- a/stroom-proxy/stroom-proxy-app/src/main/java/stroom/proxy/app/ProxyOpenIdConfig.java
+++ b/stroom-proxy/stroom-proxy-app/src/main/java/stroom/proxy/app/ProxyOpenIdConfig.java
@@ -2,7 +2,6 @@ package stroom.proxy.app;
 
 import stroom.security.openid.api.AbstractOpenIdConfig;
 import stroom.security.openid.api.IdpType;
-import stroom.util.http.HttpClientConfiguration;
 import stroom.util.shared.IsProxyConfig;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -42,8 +41,7 @@ public class ProxyOpenIdConfig extends AbstractOpenIdConfig implements IsProxyCo
             @JsonProperty("validIssuers") final Set<String> validIssuers,
             @JsonProperty("uniqueIdentityClaim") final String uniqueIdentityClaim,
             @JsonProperty("userDisplayNameClaim") final String userDisplayNameClaim,
-            @JsonProperty(PROP_NAME_EXPECTED_SIGNER_PREFIXES) final Set<String> expectedSignerPrefixes,
-            @JsonProperty("httpClient") final HttpClientConfiguration httpClient) {
+            @JsonProperty(PROP_NAME_EXPECTED_SIGNER_PREFIXES) final Set<String> expectedSignerPrefixes) {
 
         super(identityProviderType,
                 openIdConfigurationEndpoint,
@@ -62,8 +60,7 @@ public class ProxyOpenIdConfig extends AbstractOpenIdConfig implements IsProxyCo
                 validIssuers,
                 uniqueIdentityClaim,
                 userDisplayNameClaim,
-                expectedSignerPrefixes,
-                httpClient);
+                expectedSignerPrefixes);
     }
 
     @JsonIgnore
@@ -113,7 +110,6 @@ public class ProxyOpenIdConfig extends AbstractOpenIdConfig implements IsProxyCo
                 getValidIssuers(),
                 getUniqueIdentityClaim(),
                 getUserDisplayNameClaim(),
-                getExpectedSignerPrefixes(),
-                getHttpClient());
+                getExpectedSignerPrefixes());
     }
 }

--- a/stroom-proxy/stroom-proxy-app/src/test/resources/stroom/dist/proxy-expected.yaml
+++ b/stroom-proxy/stroom-proxy-app/src/test/resources/stroom/dist/proxy-expected.yaml
@@ -119,7 +119,6 @@ proxyConfig:
         clientSecret: null
         expectedSignerPrefixes: []
         formTokenRequest: true
-        httpClient: null
         identityProviderType: "NO_IDP"
         issuer: null
         jwksUri: null

--- a/stroom-security/stroom-security-common-impl/src/main/java/stroom/security/common/impl/ExternalIdpConfigurationProvider.java
+++ b/stroom-security/stroom-security-common-impl/src/main/java/stroom/security/common/impl/ExternalIdpConfigurationProvider.java
@@ -8,9 +8,8 @@ import stroom.security.openid.api.OpenIdConfigurationResponse;
 import stroom.security.openid.api.OpenIdConfigurationResponse.Builder;
 import stroom.util.HasHealthCheck;
 import stroom.util.NullSafe;
-import stroom.util.http.HttpClientConfiguration;
-import stroom.util.http.HttpClientFactory;
-import stroom.util.io.StreamUtil;
+import stroom.util.jersey.JerseyClientFactory;
+import stroom.util.jersey.JerseyClientName;
 import stroom.util.logging.LambdaLogger;
 import stroom.util.logging.LambdaLoggerFactory;
 import stroom.util.logging.LogUtil;
@@ -23,20 +22,16 @@ import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
 import jakarta.servlet.http.HttpServletResponse;
-import org.apache.hc.client5.http.classic.HttpClient;
-import org.apache.hc.client5.http.classic.methods.HttpGet;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-import org.apache.hc.core5.http.HttpEntity;
-import org.apache.hc.core5.io.CloseMode;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -52,22 +47,20 @@ public class ExternalIdpConfigurationProvider
     private static final LambdaLogger LOGGER = LambdaLoggerFactory.getLogger(ExternalIdpConfigurationProvider.class);
     private static final long MAX_SLEEP_TIME_MS = 30_000;
 
-    private final HttpClientFactory httpClientFactory;
+    private final JerseyClientFactory jerseyClientFactory;
     // Important to use AbstractOpenIdConfig here and not OpenIdConfiguration as the former
     // is bound to the yaml config, the latter is what we are presenting this as.
     private final Provider<AbstractOpenIdConfig> localOpenIdConfigProvider;
 
     private volatile String lastConfigurationEndpoint;
     private volatile OpenIdConfigurationResponse openIdConfigurationResp;
-    private volatile CloseableHttpClient currentHttpClient;
-    private volatile HttpClientConfiguration currentHttpClientConfiguration;
 
     @Inject
     public ExternalIdpConfigurationProvider(
-            final HttpClientFactory httpClientFactory,
-            final Provider<AbstractOpenIdConfig> localOpenIdConfigProvider) {
-        this.httpClientFactory = httpClientFactory;
+            final Provider<AbstractOpenIdConfig> localOpenIdConfigProvider,
+            final JerseyClientFactory jerseyClientFactory) {
         this.localOpenIdConfigProvider = localOpenIdConfigProvider;
+        this.jerseyClientFactory = jerseyClientFactory;
     }
 
     @Override
@@ -76,25 +69,10 @@ public class ExternalIdpConfigurationProvider
         final String configurationEndpoint = abstractOpenIdConfig.getOpenIdConfigurationEndpoint();
 
         if (isFetchRequired(configurationEndpoint)) {
-            updateOpenIdConfigurationResponse(abstractOpenIdConfig, getHttpClient(abstractOpenIdConfig));
+            updateOpenIdConfigurationResponse(abstractOpenIdConfig);
         }
 
         return openIdConfigurationResp;
-    }
-
-    private synchronized HttpClient getHttpClient(final AbstractOpenIdConfig abstractOpenIdConfig) {
-        if (currentHttpClient == null ||
-            !Objects.equals(abstractOpenIdConfig.getHttpClient(), currentHttpClientConfiguration)) {
-            if (currentHttpClient != null) {
-                currentHttpClient.close(CloseMode.IMMEDIATE);
-            }
-
-            currentHttpClientConfiguration = abstractOpenIdConfig.getHttpClient();
-            currentHttpClient = httpClientFactory.get(
-                    "ExternalIdpConfigurationProvider-" + UUID.randomUUID(),
-                    currentHttpClientConfiguration);
-        }
-        return currentHttpClient;
     }
 
     @Override
@@ -124,7 +102,7 @@ public class ExternalIdpConfigurationProvider
             try {
                 resultBuilder.withDetail("configUri", configurationEndpoint);
                 OpenIdConfigurationResponse response = fetchOpenIdConfigurationResponse(
-                        configurationEndpoint, abstractOpenIdConfig, getHttpClient(abstractOpenIdConfig));
+                        configurationEndpoint, abstractOpenIdConfig);
                 if (response != null) {
                     resultBuilder.healthy();
                 } else {
@@ -147,8 +125,7 @@ public class ExternalIdpConfigurationProvider
     }
 
     private OpenIdConfigurationResponse updateOpenIdConfigurationResponse(
-            final AbstractOpenIdConfig abstractOpenIdConfig,
-            final HttpClient httpClient) {
+            final AbstractOpenIdConfig abstractOpenIdConfig) {
         final String configurationEndpoint = abstractOpenIdConfig.getOpenIdConfigurationEndpoint();
 
         LOGGER.debug("About to get lock to update open id configuration");
@@ -158,7 +135,7 @@ public class ExternalIdpConfigurationProvider
             if (isFetchRequired(configurationEndpoint)) {
                 try {
                     final OpenIdConfigurationResponse response = fetchOpenIdConfigurationResponse(
-                            configurationEndpoint, abstractOpenIdConfig, httpClient);
+                            configurationEndpoint, abstractOpenIdConfig);
                     openIdConfigurationResp = mergeResponse(response, abstractOpenIdConfig);
                 } catch (final RuntimeException | IOException e) {
                     LOGGER.error(e.getMessage(), e);
@@ -181,8 +158,7 @@ public class ExternalIdpConfigurationProvider
 
     private OpenIdConfigurationResponse fetchOpenIdConfigurationResponse(
             final String configurationEndpoint,
-            final AbstractOpenIdConfig abstractOpenIdConfig,
-            final HttpClient httpClient) throws IOException {
+            final AbstractOpenIdConfig abstractOpenIdConfig) throws IOException {
 
         Objects.requireNonNull(configurationEndpoint,
                 "Property "
@@ -190,30 +166,35 @@ public class ExternalIdpConfigurationProvider
                 + " has not been set");
         LOGGER.info("Fetching open id configuration from: " + configurationEndpoint);
 
-        final HttpGet httpGet = new HttpGet(configurationEndpoint);
+//        final HttpGet httpGet = new HttpGet(configurationEndpoint);
         long sleepMs = 500;
         Throwable lastThrowable = null;
 
         while (true) {
             try {
-                return httpClient.execute(httpGet, response -> {
-                    if (HttpServletResponse.SC_OK == response.getCode()) {
-                        final HttpEntity entity = response.getEntity();
-                        String msg;
-                        try (final InputStream is = entity.getContent()) {
-                            msg = StreamUtil.streamToString(is);
-                        }
+                final WebTarget webTarget = jerseyClientFactory.getNamedClient(JerseyClientName.OPEN_ID)
+                        .target(configurationEndpoint);
 
+                try (Response response = webTarget.request(MediaType.APPLICATION_JSON).get()) {
+                    if (response.getStatus() == HttpServletResponse.SC_OK) {
+                        // According to the spec, the response may contain unexpected props so as we don't easily
+                        // have access to configure the client to relax jackson, do it manually.
+                        // https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationResponse
+                        final String responseJson = response.readEntity(String.class);
+                        LOGGER.debug("configurationEndpoint: '{}'\n{}",
+                                configurationEndpoint,
+                                responseJson);
                         final OpenIdConfigurationResponse openIdConfigurationResponse = parseConfigurationResponse(
                                 configurationEndpoint,
-                                msg);
+                                responseJson);
+
                         LOGGER.info("Successfully fetched open id configuration from: " + configurationEndpoint);
                         return openIdConfigurationResponse;
                     } else {
-                        throw new AuthenticationException("Received status " + response.getCode() +
+                        throw new AuthenticationException("Received status " + response.getStatus() +
                                                           " from " + configurationEndpoint);
                     }
-                });
+                }
             } catch (AuthenticationException e) {
                 // This is not a connection issue so just bubble it up and likely crash the app
                 // if this is happening as part of the guice injector init.

--- a/stroom-security/stroom-security-impl/src/main/java/stroom/security/impl/StroomOpenIdConfig.java
+++ b/stroom-security/stroom-security-impl/src/main/java/stroom/security/impl/StroomOpenIdConfig.java
@@ -4,7 +4,6 @@ import stroom.security.openid.api.AbstractOpenIdConfig;
 import stroom.security.openid.api.IdpType;
 import stroom.util.config.annotations.RequiresRestart;
 import stroom.util.config.annotations.RequiresRestart.RestartScope;
-import stroom.util.http.HttpClientConfiguration;
 import stroom.util.shared.IsStroomConfig;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -42,8 +41,7 @@ public class StroomOpenIdConfig extends AbstractOpenIdConfig implements IsStroom
             @JsonProperty("validIssuers") final Set<String> validIssuers,
             @JsonProperty("uniqueIdentityClaim") final String uniqueIdentityClaim,
             @JsonProperty("userDisplayNameClaim") final String userDisplayNameClaim,
-            @JsonProperty(PROP_NAME_EXPECTED_SIGNER_PREFIXES) final Set<String> expectedSignerPrefixes,
-            @JsonProperty("httpClient") final HttpClientConfiguration httpClient) {
+            @JsonProperty(PROP_NAME_EXPECTED_SIGNER_PREFIXES) final Set<String> expectedSignerPrefixes) {
         super(identityProviderType,
                 openIdConfigurationEndpoint,
                 issuer,
@@ -61,8 +59,7 @@ public class StroomOpenIdConfig extends AbstractOpenIdConfig implements IsStroom
                 validIssuers,
                 uniqueIdentityClaim,
                 userDisplayNameClaim,
-                expectedSignerPrefixes,
-                httpClient);
+                expectedSignerPrefixes);
     }
 
     @RequiresRestart(RestartScope.SYSTEM)
@@ -101,7 +98,6 @@ public class StroomOpenIdConfig extends AbstractOpenIdConfig implements IsStroom
                 getValidIssuers(),
                 getUniqueIdentityClaim(),
                 getUserDisplayNameClaim(),
-                getExpectedSignerPrefixes(),
-                getHttpClient());
+                getExpectedSignerPrefixes());
     }
 }

--- a/stroom-security/stroom-security-openid-api/src/main/java/stroom/security/openid/api/AbstractOpenIdConfig.java
+++ b/stroom-security/stroom-security-openid-api/src/main/java/stroom/security/openid/api/AbstractOpenIdConfig.java
@@ -1,6 +1,5 @@
 package stroom.security.openid.api;
 
-import stroom.util.http.HttpClientConfiguration;
 import stroom.util.shared.AbstractConfig;
 import stroom.util.shared.validation.AllMatchPattern;
 
@@ -130,8 +129,6 @@ public abstract class AbstractOpenIdConfig
 
     private final Set<String> expectedSignerPrefixes;
 
-    private final HttpClientConfiguration httpClient;
-
     public AbstractOpenIdConfig() {
         identityProviderType = getDefaultIdpType();
         openIdConfigurationEndpoint = null;
@@ -151,7 +148,6 @@ public abstract class AbstractOpenIdConfig
         uniqueIdentityClaim = OpenId.CLAIM__SUBJECT;
         userDisplayNameClaim = OpenId.CLAIM__PREFERRED_USERNAME;
         expectedSignerPrefixes = Collections.emptySet();
-        httpClient = null;
     }
 
     @JsonIgnore
@@ -176,8 +172,7 @@ public abstract class AbstractOpenIdConfig
             @JsonProperty("validIssuers") final Set<String> validIssuers,
             @JsonProperty("uniqueIdentityClaim") final String uniqueIdentityClaim,
             @JsonProperty("userDisplayNameClaim") final String userDisplayNameClaim,
-            @JsonProperty(PROP_NAME_EXPECTED_SIGNER_PREFIXES) final Set<String> expectedSignerPrefixes,
-            @JsonProperty("httpClient") final HttpClientConfiguration httpClient) {
+            @JsonProperty(PROP_NAME_EXPECTED_SIGNER_PREFIXES) final Set<String> expectedSignerPrefixes) {
 
         this.identityProviderType = identityProviderType;
         this.openIdConfigurationEndpoint = openIdConfigurationEndpoint;
@@ -197,7 +192,6 @@ public abstract class AbstractOpenIdConfig
         this.uniqueIdentityClaim = uniqueIdentityClaim;
         this.userDisplayNameClaim = userDisplayNameClaim;
         this.expectedSignerPrefixes = expectedSignerPrefixes;
-        this.httpClient = httpClient;
     }
 
     /**
@@ -384,12 +378,6 @@ public abstract class AbstractOpenIdConfig
                || (openIdConfigurationEndpoint != null && !openIdConfigurationEndpoint.isBlank());
     }
 
-    @JsonProperty
-    @JsonPropertyDescription("Configuration for the HTTP client to communicate with the external IDP")
-    public HttpClientConfiguration getHttpClient() {
-        return httpClient;
-    }
-
     @Override
     public String toString() {
         return "OpenIdConfig{" +
@@ -408,7 +396,6 @@ public abstract class AbstractOpenIdConfig
                ", validateAudience=" + validateAudience +
                ", uniqueIdentityClaim=" + uniqueIdentityClaim +
                ", expectedSignerPrefixes=" + expectedSignerPrefixes +
-               ", httpClientConfiguration=" + httpClient +
                '}';
     }
 
@@ -435,8 +422,7 @@ public abstract class AbstractOpenIdConfig
                Objects.equals(clientSecret, that.clientSecret) &&
                Objects.equals(requestScopes, that.requestScopes) &&
                Objects.equals(uniqueIdentityClaim, that.uniqueIdentityClaim) &&
-               Objects.equals(expectedSignerPrefixes, that.expectedSignerPrefixes) &&
-               Objects.equals(httpClient, that.httpClient);
+               Objects.equals(expectedSignerPrefixes, that.expectedSignerPrefixes);
     }
 
     @Override
@@ -455,7 +441,6 @@ public abstract class AbstractOpenIdConfig
                 requestScopes,
                 validateAudience,
                 uniqueIdentityClaim,
-                expectedSignerPrefixes,
-                httpClient);
+                expectedSignerPrefixes);
     }
 }

--- a/unreleased_changes/20250403_094717_358__4837.md
+++ b/unreleased_changes/20250403_094717_358__4837.md
@@ -1,0 +1,24 @@
+* Issue **#4837** : Change the fetching of OIDC config to use jersey client instead of Apache http client. The yaml properties `appConfig.security.authentication.openId.httpClient` and `proxyConfig.security.authentication.openId.httpClient` have been removed. Configuration of the jersey client is now done using `jerseyClients.OPEN_ID.` (see https://gchq.github.io/stroom-docs/docs/install-guide/configuration/stroom-and-proxy/common-configuration/#jersey-http-client-configuration).
+
+
+```sh
+# ********************************************************************************
+# Issue title: OIDC config GET uses httpClient, but token calls use jerseyClient
+# Issue link:  https://github.com/gchq/stroom/issues/4837
+# ********************************************************************************
+
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Issue **123** : Fix bug with an associated GitHub issue in this repository
+#
+# * Issue **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository
+#
+# * Fix bug with no associated GitHub issue.
+```


### PR DESCRIPTION
Fixes #4837