### PR TITLE
PR for #5030 - Support legacy DN format when extracting identity from certificates

### DIFF
--- a/stroom-config/stroom-config-app/src/test/resources/stroom/config/app/expected.yaml
+++ b/stroom-config/stroom-config-app/src/test/resources/stroom/config/app/expected.yaml
@@ -800,6 +800,7 @@ appConfig:
     - "Test Events"
     - "Test Reference"
     receiptPolicyUuid: null
+    x509CertificateDnFormat: "LDAP"
     x509CertificateDnHeader: "X-SSL-CLIENT-S-DN"
     x509CertificateHeader: "X-SSL-CERT"
   s3:

--- a/stroom-proxy/stroom-proxy-app/src/main/java/stroom/proxy/app/handler/RemoteFeedStatusService.java
+++ b/stroom-proxy/stroom-proxy-app/src/main/java/stroom/proxy/app/handler/RemoteFeedStatusService.java
@@ -56,6 +56,7 @@ public class RemoteFeedStatusService implements FeedStatusService, HasHealthChec
     private final Provider<FeedStatusConfig> feedStatusConfigProvider;
     private final JerseyClientFactory jerseyClientFactory;
     private final UserIdentityFactory userIdentityFactory;
+    private final GetFeedStatusRequestAdapter getFeedStatusRequestAdapter;
     private final ExecutorService executorService = Executors.newCachedThreadPool();
 
     @Inject
@@ -67,6 +68,7 @@ public class RemoteFeedStatusService implements FeedStatusService, HasHealthChec
         this.feedStatusConfigProvider = feedStatusConfigProvider;
         this.jerseyClientFactory = jerseyClientFactory;
         this.userIdentityFactory = userIdentityFactory;
+        this.getFeedStatusRequestAdapter = getFeedStatusRequestAdapter;
         this.updaters = cacheManager.createLoadingCache(
                 CACHE_NAME,
                 () -> feedStatusConfigProvider.get().getFeedStatusCache(),
@@ -87,7 +89,7 @@ public class RemoteFeedStatusService implements FeedStatusService, HasHealthChec
      */
     @Deprecated
     public GetFeedStatusResponse getFeedStatus(final GetFeedStatusRequest legacyRequest) {
-        final GetFeedStatusRequestV2 request = GetFeedStatusRequestAdapter.mapLegacyRequest(legacyRequest);
+        final GetFeedStatusRequestV2 request = getFeedStatusRequestAdapter.mapLegacyRequest(legacyRequest);
         return getFeedStatus(request);
     }
 

--- a/stroom-proxy/stroom-proxy-app/src/test/resources/stroom/dist/proxy-expected.yaml
+++ b/stroom-proxy/stroom-proxy-app/src/test/resources/stroom/dist/proxy-expected.yaml
@@ -144,6 +144,7 @@ proxyConfig:
     - "Test Events"
     - "Test Reference"
     receiptPolicyUuid: null
+    x509CertificateDnFormat: "LDAP"
     x509CertificateDnHeader: "X-SSL-CLIENT-S-DN"
     x509CertificateHeader: "X-SSL-CERT"
   security:

--- a/stroom-receive/stroom-receive-common/src/main/java/stroom/receive/common/GetFeedStatusRequestAdapter.java
+++ b/stroom-receive/stroom-receive-common/src/main/java/stroom/receive/common/GetFeedStatusRequestAdapter.java
@@ -6,16 +6,26 @@ import stroom.util.cert.CertificateExtractor;
 import stroom.util.shared.NullSafe;
 import stroom.util.shared.UserDesc;
 
+import jakarta.inject.Inject;
+
 import java.util.Collections;
 
 public class GetFeedStatusRequestAdapter {
 
-    public static GetFeedStatusRequestV2 mapLegacyRequest(final GetFeedStatusRequest legacyRequest) {
+    private final CertificateExtractor certificateExtractor;
+
+    @Inject
+    public GetFeedStatusRequestAdapter(final CertificateExtractor certificateExtractor) {
+        this.certificateExtractor = certificateExtractor;
+    }
+
+    public GetFeedStatusRequestV2 mapLegacyRequest(final GetFeedStatusRequest legacyRequest) {
         if (legacyRequest == null) {
             return null;
         } else {
             final String senderDn = legacyRequest.getSenderDn();
-            final String subjectId = NullSafe.get(senderDn, CertificateExtractor::extractCNFromDN);
+            final String subjectId = NullSafe.get(senderDn, certificateExtractor::extractCNFromDN)
+                    .orElse(null);
 
             return new GetFeedStatusRequestV2(
                     legacyRequest.getFeedName(),

--- a/stroom-receive/stroom-receive-common/src/main/java/stroom/receive/common/ReceiveDataConfig.java
+++ b/stroom-receive/stroom-receive-common/src/main/java/stroom/receive/common/ReceiveDataConfig.java
@@ -3,6 +3,7 @@ package stroom.receive.common;
 import stroom.data.shared.StreamTypeNames;
 import stroom.meta.api.StandardHeaderArguments;
 import stroom.util.cache.CacheConfig;
+import stroom.util.cert.DNFormat;
 import stroom.util.collections.CollectionUtil;
 import stroom.util.shared.AbstractConfig;
 import stroom.util.shared.IsProxyConfig;
@@ -37,6 +38,7 @@ public class ReceiveDataConfig
 
     public static final String DEFAULT_X509_CERT_HEADER = "X-SSL-CERT";
     public static final String DEFAULT_X509_CERT_DN_HEADER = "X-SSL-CLIENT-S-DN";
+    public static final DNFormat DEFAULT_X509_CERT_DN_FORMAT = DNFormat.LDAP;
     public static final String PROP_NAME_ALLOWED_CERTIFICATE_PROVIDERS = "allowedCertificateProviders";
     public static final String DEFAULT_OWNER_META_KEY = StandardHeaderArguments.ACCOUNT_ID;
 
@@ -58,6 +60,8 @@ public class ReceiveDataConfig
     private final String x509CertificateHeader;
     @JsonProperty
     private final String x509CertificateDnHeader;
+    @JsonProperty
+    private final DNFormat x509CertificateDnFormat;
     @JsonProperty
     private final Set<String> allowedCertificateProviders;
     @JsonProperty
@@ -82,6 +86,7 @@ public class ReceiveDataConfig
                 .build();
         x509CertificateHeader = DEFAULT_X509_CERT_HEADER;
         x509CertificateDnHeader = DEFAULT_X509_CERT_DN_HEADER;
+        x509CertificateDnFormat = DEFAULT_X509_CERT_DN_FORMAT;
         allowedCertificateProviders = Collections.emptySet();
         feedNameGenerationEnabled = false;
         feedNameTemplate = toTemplate(
@@ -109,6 +114,7 @@ public class ReceiveDataConfig
             @JsonProperty("authenticatedDataFeedKeyCache") final CacheConfig authenticatedDataFeedKeyCache,
             @JsonProperty("x509CertificateHeader") final String x509CertificateHeader,
             @JsonProperty("x509CertificateDnHeader") final String x509CertificateDnHeader,
+            @JsonProperty("x509CertificateDnFormat") final DNFormat x509CertificateDnFormat,
             @JsonProperty(PROP_NAME_ALLOWED_CERTIFICATE_PROVIDERS) final Set<String> allowedCertificateProviders,
             @JsonProperty("feedNameGenerationEnabled") final boolean feedNameGenerationEnabled,
             @JsonProperty("feedNameTemplate") final String feedNameTemplate,
@@ -123,6 +129,7 @@ public class ReceiveDataConfig
         this.authenticatedDataFeedKeyCache = authenticatedDataFeedKeyCache;
         this.x509CertificateHeader = x509CertificateHeader;
         this.x509CertificateDnHeader = x509CertificateDnHeader;
+        this.x509CertificateDnFormat = Objects.requireNonNullElse(x509CertificateDnFormat, DEFAULT_X509_CERT_DN_FORMAT);
         this.allowedCertificateProviders = cleanSet(allowedCertificateProviders);
         this.feedNameGenerationEnabled = feedNameGenerationEnabled;
         this.feedNameTemplate = feedNameTemplate;
@@ -140,6 +147,7 @@ public class ReceiveDataConfig
                 builder.authenticatedDataFeedKeyCache,
                 builder.x509CertificateHeader,
                 builder.x509CertificateDnHeader,
+                builder.x509CertificateDnFormat,
                 builder.allowedCertificateProviders,
                 builder.feedNameGenerationEnabled,
                 builder.feedNameTemplate,
@@ -233,6 +241,12 @@ public class ReceiveDataConfig
             "authentication if a value is set and 'enabledAuthenticationTypes' includes CERTIFICATE.")
     public String getX509CertificateDnHeader() {
         return x509CertificateDnHeader;
+    }
+
+    @JsonPropertyDescription("The format of the Distinguished Name used in the certificate. Valid values are " +
+                             "LDAP and OPEN_SSL, where LDAP is the default.")
+    public DNFormat getX509CertificateDnFormat() {
+        return x509CertificateDnFormat;
     }
 
     @JsonPropertyDescription(
@@ -349,12 +363,14 @@ public class ReceiveDataConfig
         builder.authenticatedDataFeedKeyCache = receiveDataConfig.getAuthenticatedDataFeedKeyCache();
         builder.x509CertificateHeader = receiveDataConfig.getX509CertificateHeader();
         builder.x509CertificateDnHeader = receiveDataConfig.getX509CertificateDnHeader();
+        builder.x509CertificateDnFormat = receiveDataConfig.getX509CertificateDnFormat();
         builder.allowedCertificateProviders = receiveDataConfig.getAllowedCertificateProviders();
         builder.feedNameGenerationEnabled = receiveDataConfig.isFeedNameGenerationEnabled();
         builder.feedNameTemplate = receiveDataConfig.getFeedNameTemplate();
         builder.feedNameGenerationMandatoryHeaders = receiveDataConfig.getFeedNameGenerationMandatoryHeaders();
         return builder;
     }
+
 
     public static Builder builder() {
         return copy(new ReceiveDataConfig());
@@ -379,6 +395,7 @@ public class ReceiveDataConfig
         private CacheConfig authenticatedDataFeedKeyCache;
         private String x509CertificateHeader;
         private String x509CertificateDnHeader;
+        private DNFormat x509CertificateDnFormat;
         private Set<String> allowedCertificateProviders;
         private boolean feedNameGenerationEnabled;
         private String feedNameTemplate;
@@ -445,6 +462,11 @@ public class ReceiveDataConfig
 
         public Builder withX509CertificateDnHeader(final String val) {
             x509CertificateDnHeader = val;
+            return this;
+        }
+
+        public Builder withX509CertificateDnFormat(final DNFormat val) {
+            x509CertificateDnFormat = val;
             return this;
         }
 

--- a/stroom-util/src/main/java/stroom/util/cert/CertificateExtractor.java
+++ b/stroom-util/src/main/java/stroom/util/cert/CertificateExtractor.java
@@ -7,10 +7,7 @@ import jakarta.servlet.ServletRequest;
 import jakarta.servlet.http.HttpServletRequest;
 
 import java.security.cert.X509Certificate;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
-import java.util.StringTokenizer;
 
 /**
  * For extracting certificates and/or DNs from {@link HttpServletRequest}s.
@@ -26,32 +23,12 @@ public interface CertificateExtractor {
     Optional<X509Certificate> extractCertificate(ServletRequest request);
 
     /**
-     * Given a DN pull out the CN. E.g.
-     * "CN=some.server.co.uk, OU=servers, O=some organisation, C=GB" Would
+     * Given a DN and {@link DNFormat} pull out the CN. E.g.
+     * "CN=some.server.co.uk, OU=servers, O=some organisation, C=GB" and {@link DNFormat#LDAP} Would
      * return "some.server.co.uk"
      *
-     * @return null or the CN name
+     * @return The CN name or an empty {@link Optional}
      */
-    static String extractCNFromDN(final String dn) {
-        LOGGER.debug(() -> "extractCNFromDN DN = " + dn);
+    Optional<String> extractCNFromDN(final String dn);
 
-        if (dn == null) {
-            return null;
-        }
-        final StringTokenizer attributes = new StringTokenizer(dn, ",");
-        final Map<String, String> map = new HashMap<>();
-        while (attributes.hasMoreTokens()) {
-            final String token = attributes.nextToken();
-            if (token.contains("=")) {
-                final String[] parts = token.split("=");
-                if (parts.length == 2) {
-                    map.put(parts[0].trim().toUpperCase(), parts[1].trim());
-                }
-            }
-        }
-        final String cn = map.get("CN");
-        LOGGER.debug(() -> "extractCNFromDN CN = " + cn);
-
-        return cn;
-    }
 }

--- a/stroom-util/src/main/java/stroom/util/cert/DNFormat.java
+++ b/stroom-util/src/main/java/stroom/util/cert/DNFormat.java
@@ -1,0 +1,26 @@
+package stroom.util.cert;
+
+/**
+ * The format of the Distinguished Name as used in LDAP or X509 certificates.
+ */
+public enum DNFormat {
+    /**
+     * Legacy OpenSSL '/' delimited DN format.
+     */
+    OPEN_SSL("/"),
+    /**
+     * LDAP ',' delimited DN format.
+     */
+    LDAP(","),
+    ;
+
+    private final String delimiter;
+
+    DNFormat(String delimiter) {
+        this.delimiter = delimiter;
+    }
+
+    public String getDelimiter() {
+        return this.delimiter;
+    }
+}

--- a/stroom-util/src/test/java/stroom/util/cert/TestCertificateExtractor.java
+++ b/stroom-util/src/test/java/stroom/util/cert/TestCertificateExtractor.java
@@ -17,23 +17,6 @@
 package stroom.util.cert;
 
 
-import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 class TestCertificateExtractor {
 
-    @Test
-    void testSpaceInCN() {
-        final String dn = "CN=John Smith (johnsmith), OU=ouCode1, OU=ouCode2, O=oValue, C=GB";
-
-//        Assertions.assertThat(CertificateUtil.dnToRfc2253(dn)).isEqualTo(
-//                "CN=John Smith (johnsmith),OU=ouCode1,OU=ouCode2,O=oValue,C=GB");
-        assertThat(CertificateExtractor.extractCNFromDN(dn))
-                .isEqualTo("John Smith (johnsmith)");
-//        assertThat(CertificateUtil.extractUserIdFromCN(CertificateUtil.extractCNFromDN(dn))).isEqualTo("johnsmith");
-//
-//        final Pattern pattern = Pattern.compile("CN=[^ ]+ [^ ]+ \\(?([a-zA-Z0-9]+)\\)?");
-//        assertThat(CertificateUtil.extractUserIdFromDN(dn, pattern)).isEqualTo("johnsmith");
-    }
 }

--- a/unreleased_changes/20250715_152934_118__5030.md
+++ b/unreleased_changes/20250715_152934_118__5030.md
@@ -1,0 +1,24 @@
+* Issue **#5030** : Add new property `.receive.x509CertificateDnFormat` to stroom and proxy to allow extraction of CNs from DNs in legacy `OPEN_SSL` format. The new property defaults to `LDAP`, which means no change to behaviour if left as is.
+
+
+```sh
+# ********************************************************************************
+# Issue title: Support legacy DN format when extracting identity from certificates
+# Issue link:  https://github.com/gchq/stroom/issues/5030
+# ********************************************************************************
+
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Issue **123** : Fix bug with an associated GitHub issue in this repository
+#
+# * Issue **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository
+#
+# * Fix bug with no associated GitHub issue.
+```


### PR DESCRIPTION
Fixes #5030