### PR TITLE
Fix Null Pointer exception that occurred in UI 

### DIFF
--- a/stroom-core-client/src/main/java/stroom/contentstore/client/presenter/ContentStoreContentPackListPresenter.java
+++ b/stroom-core-client/src/main/java/stroom/contentstore/client/presenter/ContentStoreContentPackListPresenter.java
@@ -318,16 +318,20 @@ public class ContentStoreContentPackListPresenter
                             .create(ContentStorePresenter.CONTENT_STORE_RESOURCE)
                             .method(res -> res.checkContentUpgradeAvailable(cpws.getContentPack()))
                             .onSuccess(upgradeAvailable -> {
-                                if (upgradeAvailable.getValue()) {
-                                    cpws.setInstallationStatus(ContentStoreContentPackStatus.CONTENT_UPGRADABLE);
-                                    contentPackStatusCache.put(cpws.getContentPack(), cpws.getInstallationStatus());
-                                    if (contentStorePresenter != null) {
-                                        contentStorePresenter.updateState();
+                                if (upgradeAvailable.isOk()) {
+                                    if (upgradeAvailable.getValue() != null && upgradeAvailable.getValue()) {
+                                        cpws.setInstallationStatus(ContentStoreContentPackStatus.CONTENT_UPGRADABLE);
+                                        contentPackStatusCache.put(cpws.getContentPack(), cpws.getInstallationStatus());
+                                        if (contentStorePresenter != null) {
+                                            contentStorePresenter.updateState();
+                                        }
+                                    } else {
+                                        contentPackStatusCache.put(cpws.getContentPack(), cpws.getInstallationStatus());
                                     }
                                 } else {
+                                    cpws.setInstallationStatus(ContentStoreContentPackStatus.ERROR);
                                     contentPackStatusCache.put(cpws.getContentPack(), cpws.getInstallationStatus());
                                 }
-
                                 // Check the next item
                                 doUpgradeCheckOn(rowIndex + 1);
                             })

--- a/stroom-core-shared/src/main/java/stroom/contentstore/shared/ContentStoreContentPackStatus.java
+++ b/stroom-core-shared/src/main/java/stroom/contentstore/shared/ContentStoreContentPackStatus.java
@@ -40,7 +40,10 @@ public enum ContentStoreContentPackStatus {
     PACK_UPGRADABLE("Pack upgradable"),
 
     /** Upgrades available with current settings */
-    CONTENT_UPGRADABLE("Content upgradable");
+    CONTENT_UPGRADABLE("Content upgradable"),
+
+    /** Error checking for upgrade status */
+    ERROR("Error checking for upgrade status");
 
     /** Shown in the UI for this enum */
     private final String description;


### PR DESCRIPTION
NPE occurred when there was an error getting data from GIT to check for upgrades. The client wasn't checking whether the check for upgrades had worked and was trying to convert the null Boolean to a boolean.