### PR TITLE
Fix for query term editor closing after one key press

### DIFF
--- a/stroom-core-client/src/main/java/stroom/query/client/ExpressionTreePresenter.java
+++ b/stroom-core-client/src/main/java/stroom/query/client/ExpressionTreePresenter.java
@@ -89,7 +89,6 @@ public class ExpressionTreePresenter extends MyPresenterWidget<ExpressionTreePre
     }
 
     public ExpressionOperator write() {
-        clearSelection();
         return new ExpressionModel().getExpressionFromTree(tree);
     }
 

--- a/stroom-core-client/src/main/java/stroom/query/client/OperatorEditor.java
+++ b/stroom-core-client/src/main/java/stroom/query/client/OperatorEditor.java
@@ -39,10 +39,7 @@ public class OperatorEditor extends Composite {
         protected void onBind() {
             super.onBind();
             registerHandler(listBox.addValueChangeHandler(event -> {
-                if (!reading && operator != null) {
-                    operator.setOp(event.getValue());
-                    onChange();
-                }
+                onChange();
             }));
         }
     };
@@ -102,7 +99,8 @@ public class OperatorEditor extends Composite {
     }
 
     private void onChange() {
-        if (!reading) {
+        if (!reading && operator != null) {
+            operator.setOp(listBox.getValue());
             if (uiHandlers != null) {
                 uiHandlers.onChange();
             }

--- a/stroom-core-client/src/main/java/stroom/query/client/TermEditor.java
+++ b/stroom-core-client/src/main/java/stroom/query/client/TermEditor.java
@@ -507,10 +507,6 @@ public class TermEditor extends Composite {
         registerHandler(dateFrom.addValueChangeHandler(e -> fireDirty()));
         registerHandler(dateTo.addValueChangeHandler(e -> fireDirty()));
 
-        registerHandler(date.addValueChangeHandler(event -> fireDirty()));
-        registerHandler(dateFrom.addValueChangeHandler(event -> fireDirty()));
-        registerHandler(dateTo.addValueChangeHandler(event -> fireDirty()));
-
         if (docSelectionBoxPresenter != null) {
             registerHandler(docSelectionBoxPresenter.addDataSelectionHandler(event -> {
                 final DocRef selection = docSelectionBoxPresenter.getSelectedEntityReference();
@@ -606,6 +602,7 @@ public class TermEditor extends Composite {
 
     private void fireDirty() {
         if (!reading) {
+            write(term);
             if (uiHandlers != null) {
                 uiHandlers.onChange();
             }


### PR DESCRIPTION
There is a bug in the Dashboard Query Editor, where the query term editor closes after one key press. This PR fixes that issue and returns the UI working state.