### PR TITLE
Fix buffer limit in PlanB Filter - clear() missing after flip()

### DIFF
--- a/stroom-planb/stroom-planb-impl/src/main/java/stroom/planb/impl/pipeline/PlanBFilter.java
+++ b/stroom-planb/stroom-planb-impl/src/main/java/stroom/planb/impl/pipeline/PlanBFilter.java
@@ -921,9 +921,11 @@ public class PlanBFilter extends AbstractXMLFilter {
         return switch (type) {
             case STRING -> ValString.create(currentStringValue);
             case XML -> {
-                final ByteBuffer value = stagingValueOutputStream.getByteBuffer();
-                value.flip();
-                yield ValXml.create(ByteBufferUtils.getBytes(value));
+                final ByteBuffer buffer = stagingValueOutputStream.getByteBuffer();
+                buffer.flip();
+                final Val val = ValXml.create(ByteBufferUtils.getBytes(buffer));
+                buffer.clear();
+                yield val;
             }
             default -> ValNull.INSTANCE;
         };


### PR DESCRIPTION
Summary of Changes

  In stroom-planb/stroom-planb-impl/src/main/java/stroom/planb/impl/pipeline/PlanBFilter.java:

   - Modified the getVal() method specifically for the XML case.
   - Added value.clear() after the ValXml is created from the flipped ByteBuffer.

  Why this was necessary
  The stagingValueOutputStream (a ByteBufferPoolOutput) is reused for every XML fragment in the stream. When getByteBuffer() is called and then flip() is used to read the data, the buffer's limit is set to the current position
  (the size of the data written). 

  Without a subsequent clear(), the buffer's limit remains restricted to that small size. When the stream is reset for the next fragment and more data is written, the underlying buffer's restricted limit eventually causes a
  crash or failure because the stream expects to be able to use the full capacity of the buffer.
'
    1 // Before
    2             case XML -> {
    3                 final ByteBuffer value = stagingValueOutputStream.getByteBuffer();
    4                 value.flip();
    5                 yield ValXml.create(ByteBufferUtils.getBytes(value));
    6             }
    7
    8 // After
    9             case XML -> {
   10                 final ByteBuffer value = stagingValueOutputStream.getByteBuffer();
   11                 value.flip();
   12                 final Val val = ValXml.create(ByteBufferUtils.getBytes(value));
   13                 value.clear(); // Correctly resets the limit and position for reuse
   14                 yield val;
   15             }
'
  The data safety is guaranteed because ValXml.create(ByteBufferUtils.getBytes(value)) creates a complete copy of the bytes into a new byte[] array before the source buffer is cleared.

See https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/nio/ByteBuffer.html#flip() for details on flip() and clear().