### PR TITLE
PR for #5549 - jnr ffi is extracting a native lib to /tmp which doesn't work if /tmp is mounted with `noexec`

### DIFF
--- a/stroom-config/stroom-config-app/src/test/resources/stroom/config/app/expected.yaml
+++ b/stroom-config/stroom-config-app/src/test/resources/stroom/config/app/expected.yaml
@@ -589,6 +589,7 @@ appConfig:
   lifecycle:
     enabled: true
   lmdbLibrary:
+    providedJffiLibraryPath: null
     providedSystemLibraryPath: null
     systemLibraryExtractDir: "lmdb_library"
   logging:

--- a/stroom-lmdb/src/main/java/stroom/lmdb/LmdbLibrary.java
+++ b/stroom-lmdb/src/main/java/stroom/lmdb/LmdbLibrary.java
@@ -21,6 +21,7 @@ import stroom.util.io.TempDirProvider;
 import stroom.util.logging.LambdaLogger;
 import stroom.util.logging.LambdaLoggerFactory;
 import stroom.util.logging.LogUtil;
+import stroom.util.shared.NullSafe;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
@@ -31,7 +32,6 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
-import java.util.Optional;
 
 @Singleton // The LMDB lib is dealt with statically by LMDB java so only want to initialise it once
 public class LmdbLibrary {
@@ -67,39 +67,96 @@ public class LmdbLibrary {
         if (!HAS_LIBRARY_BEEN_CONFIGURED) {
             LOGGER.info("Configuring LMDB system library");
 
-            final Path lmdbSystemLibraryPath = Optional.ofNullable(lmdbLibraryConfig.getProvidedSystemLibraryPath())
-                    .map(pathCreator::toAppPath)
-                    .orElse(null);
+            LOGGER.debug(() -> LogUtil.message("""
+                            configureLibraryUnderLock() - lmdbLibraryConfig: {},
+                              {},
+                              {},
+                              {},
+                              {}""",
+                    lmdbLibraryConfig,
+                    dumpSystemProp(LmdbLibraryConfig.LMDB_EXTRACT_DIR_PROP),
+                    dumpSystemProp(LmdbLibraryConfig.LMDB_NATIVE_LIB_PROP),
+                    dumpSystemProp(LmdbLibraryConfig.JFFI_EXTRACT_DIR_PROP),
+                    dumpSystemProp(LmdbLibraryConfig.JFFI_NATIVE_LIB_PROP)));
+
+            final Path lmdbSystemLibraryPath = NullSafe.get(
+                    lmdbLibraryConfig.getProvidedSystemLibraryPath(),
+                    pathCreator::toAppPath);
+            final Path jffiNativeLibraryPath = NullSafe.get(
+                    lmdbLibraryConfig.getProvidedJffiLibraryPath(),
+                    pathCreator::toAppPath);
+
+            boolean extractLmdb = false;
+            boolean extractJffi = false;
 
             if (lmdbSystemLibraryPath != null) {
                 if (!Files.isReadable(lmdbSystemLibraryPath)) {
-                    throw new RuntimeException("Unable to read LMDB system library at " +
-                            lmdbSystemLibraryPath.toAbsolutePath().normalize());
+                    throw new RuntimeException("Unable to read LMDB system library at " + lmdbSystemLibraryPath);
                 }
                 // jakarta.validation should ensure the path is valid if set
                 final String lmdbNativeLibProp = LmdbLibraryConfig.LMDB_NATIVE_LIB_PROP;
-                System.setProperty(lmdbNativeLibProp, lmdbSystemLibraryPath.toAbsolutePath().normalize().toString());
-                LOGGER.info("Using provided LMDB system library file. Setting prop {} to '{}'",
+                System.setProperty(lmdbNativeLibProp, lmdbSystemLibraryPath.toString());
+                LOGGER.info("Using provided LMDB native library file. Setting prop {} to '{}'",
                         lmdbNativeLibProp, lmdbSystemLibraryPath);
             } else {
-                final Path systemLibraryExtractDir = getLibraryExtractDir(lmdbLibraryConfig);
+                extractLmdb = true;
+            }
 
-                // LMDB extracts the lib on boot to a unique temp file and should delete on JVM exit,
+            final String jffiNativeLibProp = LmdbLibraryConfig.JFFI_NATIVE_LIB_PROP;
+            final String jffiPropVal = System.getenv(jffiNativeLibProp);
+            if (NullSafe.isNonBlankString(jffiPropVal)) {
+                LOGGER.info("Using provided JFFI native library file. Property {} already set to '{}'",
+                        jffiNativeLibProp, jffiPropVal);
+            } else if (jffiNativeLibraryPath != null) {
+                if (!Files.isReadable(jffiNativeLibraryPath)) {
+                    throw new RuntimeException("Unable to read JFFI native library at " + jffiNativeLibraryPath);
+                }
+                // jakarta.validation should ensure the path is valid if set
+                System.setProperty(jffiNativeLibProp, jffiNativeLibraryPath.toString());
+                LOGGER.info("Using provided JFFI native library file. Setting prop {} to '{}'",
+                        jffiNativeLibProp, lmdbSystemLibraryPath);
+            } else {
+                extractJffi = true;
+            }
+
+            LOGGER.debug("configureLibraryUnderLock() - extractLmdb: {}, extractJffi: {}", extractLmdb, extractJffi);
+            if (extractLmdb || extractJffi) {
+                final Path systemLibraryExtractDir = getLibraryExtractDir(lmdbLibraryConfig);
+                // LMDB/JFFI extract the lib on boot to a unique temp file and should delete on JVM exit,
                 // but just in case clear out any old ones.
                 cleanUpExtractDir(systemLibraryExtractDir);
 
+                // Extract them both to the same place as both will need a non 'noexec' mount.
+
                 // Set the location to extract the bundled LMDB binary to
-                final String lmdbExtractDirProp = LmdbLibraryConfig.LMDB_EXTRACT_DIR_PROP;
-                System.setProperty(
-                        lmdbExtractDirProp,
-                        systemLibraryExtractDir.toAbsolutePath().normalize().toString());
-                LOGGER.info("Bundled LMDB system library binary will be extracted. Setting prop {} to '{}'",
-                        lmdbExtractDirProp, systemLibraryExtractDir);
-                HAS_LIBRARY_BEEN_CONFIGURED = true;
+                if (extractLmdb) {
+                    final String lmdbExtractDirProp = LmdbLibraryConfig.LMDB_EXTRACT_DIR_PROP;
+                    System.setProperty(lmdbExtractDirProp, systemLibraryExtractDir.toString());
+                    LOGGER.info("Bundled LMDB native library binary will be extracted and used. " +
+                                "Setting system prop '{}' to '{}'",
+                            lmdbExtractDirProp, systemLibraryExtractDir);
+                }
+
+                // Set the location to extract the bundled Jffi binary to
+                if (extractJffi) {
+                    final String jffiExtractDirProp = LmdbLibraryConfig.JFFI_EXTRACT_DIR_PROP;
+                    if (System.getProperty(jffiExtractDirProp) == null) {
+                        // Allow a jvm arg to override our config
+                        System.setProperty(jffiExtractDirProp, systemLibraryExtractDir.toString());
+                        LOGGER.info("Bundled JFFI native library binary will be extracted and used. " +
+                                    "Setting system prop '{}' to '{}'",
+                                jffiExtractDirProp, systemLibraryExtractDir);
+                    }
+                }
             }
+            HAS_LIBRARY_BEEN_CONFIGURED = true;
         } else {
             LOGGER.debug("Another thread beat us to it");
         }
+    }
+
+    private String dumpSystemProp(final String propName) {
+        return "'" + propName + "': '" + System.getProperty(propName) + "'";
     }
 
     private Path getLibraryExtractDir(final LmdbLibraryConfig lmdbLibraryConfig) {
@@ -109,7 +166,8 @@ public class LmdbLibrary {
 
         Path extractDir;
         if (extractDirStr == null) {
-            LOGGER.warn("LMDB system library extract dir is not set ({}), falling back to temporary directory {}.",
+            LOGGER.warn("LMDB system library extract dir is not set ({}), falling back to temporary directory {}. " +
+                        "If the temporary directory is mounted with 'noexec' any use of LMDB will error.",
                     extractDirPropName,
                     tempDirProvider.get());
 
@@ -119,6 +177,7 @@ public class LmdbLibrary {
         } else {
             extractDir = pathCreator.toAppPath(extractDirStr);
         }
+        extractDir = extractDir.toAbsolutePath().normalize();
 
         try {
             if (LOGGER.isDebugEnabled()) {
@@ -152,21 +211,27 @@ public class LmdbLibrary {
     }
 
     private void cleanUpExtractDir(final Path extractDir) {
-        try (final DirectoryStream<Path> directoryStream = Files.newDirectoryStream(
-                extractDir, "lmdbjava-native-library-*.so")) {
+        cleanUpExtractDir(extractDir, "lmdbjava-native-library-*.so", "LMDB native library");
+        // The jffi file should not really ever be there because it is deleted once loaded, but just in case
+        // See com.kenai.jffi.internal.StubLoader
+        cleanUpExtractDir(extractDir, "jffi*.so", "JFFI native library");
+    }
 
-            for (final Path redundantLibraryFilePath : directoryStream) {
-                LOGGER.info("Deleting redundant LMDB library file "
-                        + redundantLibraryFilePath.toAbsolutePath().normalize());
+    private static void cleanUpExtractDir(final Path extractDir, final String glob, final String name) {
+        try (final DirectoryStream<Path> directoryStream = Files.newDirectoryStream(extractDir, glob)) {
+            for (final Path file : directoryStream) {
+                LOGGER.info("Deleting redundant {} file {}", name, file.toAbsolutePath().normalize());
                 try {
-                    Files.deleteIfExists(redundantLibraryFilePath);
+                    Files.deleteIfExists(file);
                 } catch (final IOException e) {
-                    LOGGER.error("Unable to delete file " + extractDir.toAbsolutePath().normalize(), e);
+                    LOGGER.error(() -> LogUtil.message("Unable to delete {} file {}",
+                            name, file.toAbsolutePath().normalize()), e);
                     // swallow error as these old files don't matter really
                 }
             }
         } catch (final IOException e) {
-            throw new RuntimeException("Error listing contents of " + extractDir.toAbsolutePath().normalize());
+            throw new RuntimeException(LogUtil.message("Error listing contents of {} with glob '{}'",
+                    extractDir.toAbsolutePath().normalize(), glob));
         }
     }
 }

--- a/stroom-lmdb/src/main/java/stroom/lmdb/LmdbLibraryConfig.java
+++ b/stroom-lmdb/src/main/java/stroom/lmdb/LmdbLibraryConfig.java
@@ -32,46 +32,72 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 public class LmdbLibraryConfig extends AbstractConfig implements IsStroomConfig {
 
     static final String SYSTEM_LIBRARY_PATH_PROP_NAME = "providedSystemLibraryPath";
+    static final String JFFI_LIBRARY_PATH_PROP_NAME = "providedJffiLibraryPath";
     static final String EXTRACT_DIR_PROP_NAME = "systemLibraryExtractDir";
     static final String DEFAULT_LIBRARY_EXTRACT_SUB_DIR_NAME = "lmdb_library";
 
     // These are dups of org.lmdbjava.Library.LMDB_* but that class is pkg private for some reason.
     public static final String LMDB_EXTRACT_DIR_PROP = "lmdbjava.extract.dir";
     public static final String LMDB_NATIVE_LIB_PROP = "lmdbjava.native.lib";
+    public static final String JFFI_EXTRACT_DIR_PROP = "jffi.extract.dir";
+    public static final String JFFI_NATIVE_LIB_PROP = "jffi.boot.library.path";
 
     private final String providedSystemLibraryPath;
+    private final String providedJffiLibraryPath;
     private final String systemLibraryExtractDir;
 
     public LmdbLibraryConfig() {
         providedSystemLibraryPath = null;
+        providedJffiLibraryPath = null;
         systemLibraryExtractDir = DEFAULT_LIBRARY_EXTRACT_SUB_DIR_NAME;
     }
 
     @SuppressWarnings("unused")
     @JsonCreator
     public LmdbLibraryConfig(@JsonProperty(SYSTEM_LIBRARY_PATH_PROP_NAME) final String providedSystemLibraryPath,
+                             @JsonProperty(JFFI_LIBRARY_PATH_PROP_NAME) final String providedJffiLibraryPath,
                              @JsonProperty(EXTRACT_DIR_PROP_NAME) final String systemLibraryExtractDir) {
         this.providedSystemLibraryPath = providedSystemLibraryPath;
+        this.providedJffiLibraryPath = providedJffiLibraryPath;
         this.systemLibraryExtractDir = systemLibraryExtractDir;
     }
 
     @ValidFilePath
     @RequiresRestart(RestartScope.SYSTEM)
     @JsonProperty(SYSTEM_LIBRARY_PATH_PROP_NAME)
-    @JsonPropertyDescription("The path to a provided LMDB system library file. If unset the LMDB binary " +
+    @JsonPropertyDescription(
+            "The path to a provided LMDB native library file. If unset the LMDB binary " +
             "bundled with Stroom will be extracted to 'systemLibraryExtractDir'. This property can be used if " +
             "you already have LMDB installed or want to make use of a package manager provided instance. " +
-            "If you set this property care needs  to be taken over version compatibility between the version " +
-            "of LMDBJava (that Stroom uses to interact with LMDB) and the version of the LMDB binary.")
+            "If you set this property care needs to be taken over version compatibility between the version " +
+            "of LMDBJava (that Stroom uses to interact with LMDB) and the version of the LMDB binary. " +
+            "By default this is unset.")
     public String getProvidedSystemLibraryPath() {
         return providedSystemLibraryPath;
     }
 
+    @ValidFilePath
+    @RequiresRestart(RestartScope.SYSTEM)
+    @JsonProperty(JFFI_LIBRARY_PATH_PROP_NAME)
+    @JsonPropertyDescription(
+            "The path to a provided JFFI native library file, which is used by LMDBJava. If unset the JFFI binary " +
+            "bundled with Stroom will be extracted to 'systemLibraryExtractDir'. This property can be used if " +
+            "you provide your own version of JFFI. " +
+            "If you set this property care needs to be taken over version compatibility between the version " +
+            "of JFFI and the version of the JFFI binary. " +
+            "By default this is unset.")
+    public String getProvidedJffiLibraryPath() {
+        return providedJffiLibraryPath;
+    }
+
     @RequiresRestart(RestartScope.SYSTEM)
     @JsonProperty(EXTRACT_DIR_PROP_NAME)
-    @JsonPropertyDescription("The directory to extract the bundled LMDB system library to. Only used if " +
-            "property providedSystemLibraryPath is not set. On boot Stroom will extract the LMDB binary to this " +
-            "location. It will also delete old copies of the LMDB system library if found.")
+    @JsonPropertyDescription(
+            "The directory to extract the bundled LMDB and JFFI native libraries to. Only used if " +
+            "property providedSystemLibraryPath or property providedJffiLibraryPath are not set. " +
+            "On boot Stroom will clear this directory and then extract the native libraries into it. " +
+            "IMPORTANT: This directory must not have the 'noexec' mount option, or all LMDB use will error. " +
+            "Also, the contents are ephemeral, so should ideally be mounted using tmpfs or similar.")
     public String getSystemLibraryExtractDir() {
         return systemLibraryExtractDir;
     }
@@ -79,12 +105,16 @@ public class LmdbLibraryConfig extends AbstractConfig implements IsStroomConfig 
     @Override
     public String toString() {
         return "LmdbLibraryConfig{" +
-                "providedSystemLibraryPath='" + providedSystemLibraryPath + '\'' +
-                ", systemLibraryExtractDir='" + systemLibraryExtractDir + '\'' +
-                '}';
+               "providedSystemLibraryPath='" + providedSystemLibraryPath + '\'' +
+               ", providedJffiLibraryPath='" + providedJffiLibraryPath + '\'' +
+               ", systemLibraryExtractDir='" + systemLibraryExtractDir + '\'' +
+               '}';
     }
 
     public LmdbLibraryConfig withSystemLibraryExtractDir(final String systemLibraryExtractDir) {
-        return new LmdbLibraryConfig(providedSystemLibraryPath, systemLibraryExtractDir);
+        return new LmdbLibraryConfig(
+                providedSystemLibraryPath,
+                providedJffiLibraryPath,
+                systemLibraryExtractDir);
     }
 }

--- a/unreleased_changes/20260520_163807_374__5549.md
+++ b/unreleased_changes/20260520_163807_374__5549.md
@@ -1,0 +1,68 @@
+* Bug **#5549** : Make jffi extract its native library to the same dir as the LMDB native library file. Add the config prop `providedJffiLibraryPath` to allow for a provided jffi lib.
+
+
+```sh
+# ********************************************************************************
+# Issue number: 5549
+# Issue title:  jnr ffi is extracting a native lib to /tmp which doesn't work if /tmp is mounted with `noexec`
+# Issue tags:   
+# Issue link:   https://github.com/gchq/stroom/issues/5549
+# ********************************************************************************
+
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Bug **#123** : Fix bug with an associated GitHub issue in this repository.
+#
+# * Bug **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository.
+#
+# * Feature **#789** : Add new feature X.
+#
+# * Bug : Fix bug with no associated GitHub issue.
+#
+#
+# Note: The line must start '* XXX ', where 'XXX' is a valid category,
+#       one of [Bug Feature Refactor Dependency Build].
+
+
+# --------------------------------------------------------------------------------
+# The following is random text to make this file unique for git's change detection
+# yycVukXmxnlCAvZEVr03hHqhXGL3WkEckGhJy1PhtNfSCJ2BRoJRC1dsMe0twcmyeGEOCvbPJmRW4kXp
+# 6YQZJKkZpswT3rLro2bAzxxjPthiR4uQAPR8Jq5u3nbIC2t3tYFe3foegMPm4vN7x1OYCwDCjU024R5G
+# Ig8Agidd79meRXr7mAOPdua5WWAKYaaXS2YrvCuEWkGa1echsybpCtfnRSX029gwPxkjxVa60IiaU4yN
+# V9K1MEUbJcjenOkOqiLOb1nNEHl0d7U5EZvGa977HFpR6lsVkX1SZghQRThJBdM8tgktKsPtXGahjqQ4
+# pOa4PTzfHVlgWzrWLQ47x6SWNj8ETLjjNwQWC27MTCLzGwHFgxW8pEwXBBWZZuKUw9lDiLLqQ8QQXwdk
+# UK5I7gXbUMwZt9py8AKS1K8UuOjNKuR9n78F0PDcnblEk64LazDddDmAGZjmpuRzfY18SecgA8JqwJTq
+# 6eTiVEDg3vN3WeTNDEdxTgQfXLEFEJgcj3HEDL9zeTgf88Th0d8UWLGmZFG9PdVW5hEzp2iBPdzvOrlH
+# HHem4YK2nIBOTMJgOpMZTvnkSACroCWXNBydjRPaTyDf7VjC2Hne1DF6HADCMjfRy5BiYREQh8U2OfL8
+# VHqDXYFm1zGJQYJGpWNmpNxYneEsSywFCz8b5YDQ7Xa1UQBgFS7IfmWNtMY4YzXOQ7LZ1G5dSYBna4wc
+# koTY1TYNQyWUfro89rhl5DIfxZ8AaBKV85oQrdrCqrj9jSkRPosDHKQOkHOEoxd7uViBwnd39ViBABR1
+# qOVgW9iuNKCPWRP8ShNG4OjKmc46SuPVLgLxlQV08hJzobW4S2iJjFo91D1Ca0eZjj9SN1StDQi1RITD
+# yLP63yulM0F3NGYELbKlBKgpglfivNBkltTP7RHFfKYLZRYHYZaF9LK6LBSs1XicHwYw4q0AhlEhmDiL
+# JZ57SrHf73IkPK2WWRRuVpECnrqsz55VjHoHbNXir52ERbgSuCSaEhJBYtm8CLjsynSzk4FvzYQxYZk6
+# tgAX5UrVB6XmvkbzJj1b2SNhpljklNDzgP7UD6R1Fmu6RvPE8XvCsjKYrUcv4JRPPtZL3lKA6teWdlGU
+# TmutuFaEqkrDuRWUNOADPwMz62pCjv2zCI5HfyhaD77oUNMmdfDqpu4AwKRYGKqMw0GYp6a9vVdNjO8l
+# q4alUw6IO57BCKfjQ9mweQL6VSfA3adasx3V9AhOehK4pkyWbrOS0FNmmnbDHH5X0J6DZTsk36lkvWbC
+# Ns5VU4eG3itbs1txXUPRJVImxNZAYecjKrzWWg5IdixyJyDu723qUVibAelwEfcs1sB06SLR0lwa4tMi
+# wAsUpzHkkFCTdXXpAmLPmMQErXDCSitGKqNTV3FW9u1N6TWqhQsmvSY3yG8lroXpUZHeAcFsADdSwNbm
+# bt0ic0JEiNlmYnAaMmHUpAunBQmobinpPRIV3eG4qvutSkMQSccjA6kWGA95i1egCFuvIedLbPCvvd5h
+# lnuqzdoI2jntj9DcSwu6ySJDLUdzE3XqUl0iQ0yIefU9lV07ql3QmscPQhfisMMjXsIhuo2aMW89Q8wk
+# bqHSEjQLjFQAcmgupSulSzY9vI3w1p5N6k8XK1u8pAaHLQtg4FEeNEREoJxigf5Ra5qzfv0IEVC3qsFn
+# LPsEqjqmYCNdgipHsPeTrBWMZNobXmiIjeEeKsGECgDp60qbLoz4QlLjRlYSIyad86urBdTpct89G1VG
+# 2W8o5uJLzH2snqe7ELaJTPWsgPetTMXC4XXsm1sVuPaQOBwPJNpfznwBRuWicfz7r7Xm3YK2TUJhTLF3
+# wFkbXOoseLCqsORnsrZhUO9zDWOFsRu3Xq92AXYhtXs7v8AIVCJZsovHqcKFpCPYEAdBsYNK37nt5H80
+# Gzm5p6vhd4NmnVIXPdkvX5dLdc2v07jZmFqfqzgHXqrYKhihDPDVTifJQjo6abXZB0M9ArVEWshR6jyc
+# Iskeiz0l99eyuzSlAJ3ilL7WNIK4fi2Rwe2fvU8MqNhPMvxarMxfEQ3NDVrMWHAZWwJab9OkJ1LUaxea
+# hyk7D3S35OXuVqupC2dZhdIXSz3yoztzwk9izNCPZStXuM5KjI4PpVsuzrg8KecHO7CUulxGbNHsldRA
+# StcTwS8YNeQfliUq11tQkWGxS4WJMZE0mlGoObwYv7mn04s5EgOhKWFEJjIc3oHrLMnXYWI34OaYqxwX
+# K70n3u7R8tfWuTeNnhLf8PdEN2k5bVSoSePbPmfxjS5cgnqE9UlXSq2jOVM0ap2ShOAephE9Y59YgP6x
+# KxGYUixKTJyW9OxxcZLTHm2MIkfZo376iiGSPjA1TCJNldfHL37kHlYVb9fjQN0OKGPnuDPRkOliIJp0
+# --------------------------------------------------------------------------------
+
+```


### PR DESCRIPTION
Fixes #5549