### PR TITLE
Add cosine-similarity XSLT function

### DIFF
--- a/stroom-pipeline/src/main/java/stroom/pipeline/xsltfunctions/CommonXsltFunctionModule.java
+++ b/stroom-pipeline/src/main/java/stroom/pipeline/xsltfunctions/CommonXsltFunctionModule.java
@@ -39,6 +39,7 @@ public class CommonXsltFunctionModule extends AbstractXsltFunctionModule {
         bindFunction(ClassificationFunction.class);
         bindFunction(ColFromFunction.class);
         bindFunction(ColToFunction.class);
+        bindFunction(CosineSimilarityFunction.class);
         bindFunction(CurrentTimeFunction.class);
         bindFunction(CurrentUnixTimeFunction.class);
         bindFunction(CurrentUserFunction.class);
@@ -140,6 +141,23 @@ public class CommonXsltFunctionModule extends AbstractXsltFunctionModule {
                     0,
                     new SequenceType[]{},
                     SequenceType.OPTIONAL_STRING,
+                    functionCallProvider);
+        }
+    }
+
+    private static class CosineSimilarityFunction extends StroomExtensionFunctionDefinition<CosineSimilarity> {
+
+        @Inject
+        CosineSimilarityFunction(final Provider<CosineSimilarity> functionCallProvider) {
+            super(
+                    CosineSimilarity.FUNCTION_NAME,
+                    2,
+                    2,
+                    new SequenceType[]{
+                            SequenceType.ATOMIC_SEQUENCE,
+                            SequenceType.ATOMIC_SEQUENCE
+                    },
+                    SequenceType.SINGLE_NUMERIC,
                     functionCallProvider);
         }
     }

--- a/stroom-pipeline/src/main/java/stroom/pipeline/xsltfunctions/CosineSimilarity.java
+++ b/stroom-pipeline/src/main/java/stroom/pipeline/xsltfunctions/CosineSimilarity.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2016-2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stroom.pipeline.xsltfunctions;
+
+import net.sf.saxon.expr.XPathContext;
+import net.sf.saxon.om.Item;
+import net.sf.saxon.om.Sequence;
+import net.sf.saxon.om.SequenceIterator;
+import net.sf.saxon.trans.XPathException;
+import net.sf.saxon.value.DoubleValue;
+import net.sf.saxon.value.NumericValue;
+
+public class CosineSimilarity extends StroomExtensionMetaFunctionCall {
+
+    public static final String FUNCTION_NAME = "cosine-similarity";
+
+    @Override
+    protected Sequence call(final String functionName, final XPathContext context, final Sequence[] arguments)
+            throws XPathException {
+
+        double dot = 0.0;
+        double normA = 0.0;
+        double normB = 0.0;
+
+        final SequenceIterator iteratorA = arguments[0].iterate();
+        final SequenceIterator iteratorB = arguments[1].iterate();
+
+        // Convert sequences to arrays first for safe iteration alignment
+        final float[] a = toArray(iteratorA);
+        final float[] b = toArray(iteratorB);
+
+        if (a.length != b.length) {
+            throw new XPathException("Embedding dimensions must match");
+        }
+
+        for (int i = 0; i < a.length; i++) {
+            dot += a[i] * b[i];
+            normA += a[i] * a[i];
+            normB += b[i] * b[i];
+        }
+
+        if (normA == 0 || normB == 0) {
+            return DoubleValue.ZERO;
+        }
+
+        return new DoubleValue(dot / (Math.sqrt(normA) * Math.sqrt(normB)));
+    }
+
+    private float[] toArray(final SequenceIterator iter) throws XPathException {
+        float[] buffer = new float[256];
+        int size = 0;
+
+        while (true) {
+            final Item item = iter.next();
+            if (item == null) {
+                break;
+            }
+
+            if (size == buffer.length) {
+                final float[] newBuf = new float[buffer.length * 2];
+                System.arraycopy(buffer, 0, newBuf, 0, buffer.length);
+                buffer = newBuf;
+            }
+
+            buffer[size++] = ((NumericValue) item).getFloatValue();
+        }
+
+        final float[] result = new float[size];
+        System.arraycopy(buffer, 0, result, 0, size);
+        return result;
+    }
+}

--- a/unreleased_changes/20260701_122339_439__5616.md
+++ b/unreleased_changes/20260701_122339_439__5616.md
@@ -1,0 +1,68 @@
+* Feature **#5616** : Add  XSLT function for computing the similarity of two float vectors.
+
+
+```sh
+# ********************************************************************************
+# Issue number: 5616
+# Issue title:  Add cosine similarity scoring XSLT function
+# Issue tags:   
+# Issue link:   https://github.com/gchq/stroom/issues/5616
+# ********************************************************************************
+
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Bug **#123** : Fix bug with an associated GitHub issue in this repository.
+#
+# * Bug **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository.
+#
+# * Feature **#789** : Add new feature X.
+#
+# * Bug : Fix bug with no associated GitHub issue.
+#
+#
+# Note: The line must start '* XXX ', where 'XXX' is a valid category,
+#       one of [Bug Feature Refactor Dependency Build].
+
+
+# --------------------------------------------------------------------------------
+# The following is random text to make this file unique for git's change detection
+# 3bRisAk4B2Qt8f1COfvhvDKAsU6YIS1gB0Fl0EzoE6HMNriXemQUj59OQlEX9iuxANIV89iC5VFjsS9x
+# xRybEiOENvR4xhJUKosmNPoqvqdJAGnJXLAMJzk2dsIGFVOlCMmDJRoKqBF0O0QheEdgXrTOhWNzINKb
+# qQp1JcI5tjGXMVlYgS1pXHPq6x5zpnaMV5bhuC33Ae0ZhCMVZxdEJkSlvRIjgfPKid8hQYNIbz6zBRwV
+# ZeV8GmUIVyK2J4Twoe6Gi7KsghHWuisRRHGryYo5DEinWX5PoBCzqi0utjFmlMpBAcueJ34CPPM7HZ1h
+# ww4iNmLHa0UzgpnxmqsrJApFbJqPhH0QtZBMIw0jFAQbwyZRLBHDKT8WvBuZnlcAZ3po8kFRXGs6pohg
+# VQPgi6p2utC2RxioXnNeewZt4AMZjB2kAvQv5hA3ceGTiizFBuo5FD5lQJnWOoZIQbqIhX58mpocmfni
+# tNfAZdhovZuXsoYqxjK5sVt67Nj75DbyAYY8e7STzAqdeGxRnJRhWmN9g38iacOQ8gqAx19cSIksxH5G
+# inm9d44UothlL0RF9YSs4RprT1I5TFaK3ZcbgXMkRZovBE4ZNPiFR1htFzA9KbQlqQf0rQhzk12peO4l
+# ZEIacu6ewR47aLe4iExSSM7kICKoHO9YOE510LYG0YBnWvXpn3HFhV3U1sqLIq0YXat3m49SehxFH72n
+# ChunJ2n8YBmiqGjeJCsHyxUWp2itsouKFRPglpcg8GZcOyrhnyaHmLgFFmmbRGOp6vHQy6GCE7HrOORx
+# QpOvXtNndb1i0ZhpPUaDOiFv2qi7afqGdag13P6ks1dwYjApaGB5dO2AEUWY2Vfvjf2AjT2ZiKYpo2Xd
+# FrVIhV6fVoYDSdKmMkXzswwj6vWnA5bUB9I0dNbyxhCCDenoctm5BX9erNzBjIlTGK0DAxcAXMIXIBdQ
+# RZzfh02bYlUNmheCY555FnBw2bvTau9BMhZb43aPRIxS0H1G7sq68IZo5JmPvLC0vaCahpWRYer4yg0d
+# tLMJNRyWTol6OJacthe7yMVBU3d9OU0SihwkzYgqU2Euoe5E2wpKeIIznThyAtSHAdLWZRpulLZYdfxS
+# ncFobI7LD9zr5yceOKWA3vLkWQn8cvjgYqU28JJex2QI1Psk8HvAq5ydndAWktHQ1AjcLVw3Ex5yApxr
+# B7CsCAozjwRWzNWjDy4CPo0vT9CVocdik9MEqYLj3wqmyMIuEBPJuwLBsrb8TkP0nVaob19uOu47A0Gy
+# 8A2OGILgwGR0VB58yRWkBG46Aik2T6Yy3Xd3bo44aDQf1ix3DMDQi2gXUQ9U3OQwnkvieOtEEZCcZnZG
+# amXLXv92HHbLltw5is3QOOpVatLL9JBuDQEdaLiGVrlTUWkMOYLgqYQyvOQfe39f5R5DF3kRrL4ueoRE
+# SzP8HHUM1mwYHUnetMjpXOcLy9dXpyJ1HxLO2hsp4VanfUZ390WkG4aiI96A3xjSeitDfvVGYNU2mMjf
+# 8iLvD8GX7wtey24257iBuqKhsJPHEM1hKyaNJCBVYTCkLAUPOrU8w1oKvLr7yuXRmZbo0Pb8WEIAaGVp
+# vOFvLATtuKW2Yq9tS1WvDbXZgenaYyg9VRacuxKeIc2XOGBJWd6L0xpiiblkUbqfS60iZLWjV7Y6nHtZ
+# e3FQ4XW5G96P7IeIlSgNQRV4KFrEXW4nG7v9KRCvS6T2gQ5nM0Zzp9mmgAO4pP2YcJDGJ11XS2pKcCtp
+# bnypeHGs0jHKgHXuEGw4iF7ABSEB1sjzuP9FEPNow3cRhiz6SqaFY94zK8GnpOSGQkBXhSQ7dvcSgxTr
+# I0xsQeVMeTVCEQgC28gwACPKHlUgMMfw5NkYQY6U1waXb0F0hPjgBGyiVkNpS4vIyBy27BTt9T1C5l4A
+# aAJHsLdMPFRMGdXUvSzvnWgdKMb0hMNEhaa5U5Ows0d7K8LjxAO5NqTI6s1VxlUWbpy6ZQEtDYzRqvFx
+# 3wes1HIPvkt3fpBbpGtQTpyNQLzodSbKcQ2XpR4xnuM99OhHV6gwp3ybJPKQDO2QelfpypvZ8dADpvVR
+# Cfi7kxnoXagIigsdr0YxgksaEGDnbmeR8Odu9uAmV22srQEweDJozjzk2PlTkJvWlXKaE5sc2NAVI463
+# OowY4BPGPAXurSQEgWJrFs0lFvkD15UTUUl9eqsysTRPJs0ofb0DADrarGQIXgFYUbHfdbajFpLZCs7V
+# 4LlwvYL8ZCGqg6GYsddF5kLFooeh96WtNxvTBrLc8QucDH8Rf2ybYIgeid9fbaEiOTON7IY240SyFWPU
+# 7klRiqbyPHf5KZyxw3GZAJasFvRn91iznBEmzBgLEy2iyivyNGPLwAz6PVPHiorV4dWhaChObTC1pVso
+# --------------------------------------------------------------------------------
+
+```


### PR DESCRIPTION
Useful for comparing vector embeddings generated by an OpenAI embedding model.

For instance, given a text snippet (A), you can calculate how well it satisfies a certain topic or phrase (B), by:
1. Generating vector embeddings for both A and B.
2. Computing the similarity score using `stroom:cosine-similarity($vecA, $vecB)`.
3. The closer to `1.0` the score, the more similar the two.