### PR TITLE
Support Elasticsearch nested field types in search

### DIFF
--- a/stroom-core-shared/src/main/java/stroom/search/elastic/shared/ElasticNativeTypes.java
+++ b/stroom-core-shared/src/main/java/stroom/search/elastic/shared/ElasticNativeTypes.java
@@ -54,6 +54,8 @@ public class ElasticNativeTypes {
         NATIVE_TYPE_MAP.put("ip", FieldType.IPV4_ADDRESS);
 
         NATIVE_TYPE_MAP.put("dense_vector", FieldType.DENSE_VECTOR);
+
+        NATIVE_TYPE_MAP.put("nested", FieldType.NESTED);
     }
 
     /**

--- a/stroom-query/stroom-query-api/src/main/java/stroom/query/api/datasource/FieldType.java
+++ b/stroom-query/stroom-query-api/src/main/java/stroom/query/api/datasource/FieldType.java
@@ -154,6 +154,12 @@ public enum FieldType implements HasDisplayValue, HasPrimitiveValue {
             " * 'messages relating to Blockchain technology'\n" +
             " * 'recreational activity'\n" +
             " * 'medical facilities'",
+            false),
+    NESTED(13,
+            CIKey.internStaticKey("Nested"),
+            "nested",
+            "\n" +
+            "A nested inner document, enabling joining queries.",
             false);
 
     public static final List<FieldType> TYPES = Arrays.stream(values())

--- a/stroom-search/stroom-search-elastic/src/main/java/stroom/search/elastic/search/ElasticSearchProvider.java
+++ b/stroom-search/stroom-search-elastic/src/main/java/stroom/search/elastic/search/ElasticSearchProvider.java
@@ -62,24 +62,21 @@ import co.elastic.clients.elasticsearch._types.mapping.KeywordProperty;
 import co.elastic.clients.elasticsearch._types.mapping.NumberPropertyBase;
 import co.elastic.clients.elasticsearch._types.mapping.Property;
 import co.elastic.clients.elasticsearch._types.mapping.Property.Kind;
-import co.elastic.clients.elasticsearch._types.mapping.PropertyBase;
 import co.elastic.clients.elasticsearch._types.mapping.TextProperty;
-import co.elastic.clients.elasticsearch.indices.GetFieldMappingRequest;
-import co.elastic.clients.elasticsearch.indices.GetFieldMappingResponse;
-import co.elastic.clients.elasticsearch.indices.get_field_mapping.TypeFieldMappings;
+import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
+import co.elastic.clients.elasticsearch.indices.GetMappingRequest;
+import co.elastic.clients.elasticsearch.indices.GetMappingResponse;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.Executor;
 
@@ -88,6 +85,7 @@ public class ElasticSearchProvider implements SearchProvider, ElasticIndexServic
 
     public static final String ENTITY_TYPE = ElasticIndexDoc.TYPE;
     private static final LambdaLogger LOGGER = LambdaLoggerFactory.getLogger(ElasticSearchProvider.class);
+    private static final String FIELD_PATH_SEPARATOR = ".";
 
     private final ElasticIndexCache elasticIndexCache;
     private final SecurityContext securityContext;
@@ -281,7 +279,7 @@ public class ElasticSearchProvider implements SearchProvider, ElasticIndexServic
                 .fldName(fieldName)
                 .fldType(elasticIndexFieldType)
                 .conditionSet(conditionSet)
-                .queryable(isIndexed)
+                .queryable(isIndexed && !FieldType.NESTED.equals(elasticIndexFieldType))
                 .build();
     }
 
@@ -412,10 +410,21 @@ public class ElasticSearchProvider implements SearchProvider, ElasticIndexServic
         return result;
     }
 
+    /**
+     * Reads the full, hierarchical mapping for the index and flattens it into a de-duplicated map keyed by
+     * full field name.
+     * <p>
+     * This uses the get-mapping API ({@code _mapping}) rather than the get-field-mapping API
+     * ({@code _mapping/field/*}). The latter flattens its response and does not reliably surface
+     * {@code nested} (or {@code object}) container fields, which means the nesting structure of the index is
+     * lost. The get-mapping API instead returns the complete property tree, from which the container fields
+     * and their descendants can be recovered at every level of nesting - a prerequisite for building multi
+     * level nested queries and for reading the grouped values back out of nested search hits.
+     */
     private static NavigableMap<String, FieldMapping> getFlattenedFieldMappings(
             final ElasticIndexDoc elasticIndex,
             final ElasticsearchClient elasticClient) {
-        // Flatten the mappings, which are keyed by index, into a de-duplicated list
+        // De-duplicated map keyed by full field name, ordered case-insensitively.
         final NavigableMap<String, FieldMapping> mappings = new TreeMap<>((o1, o2) -> {
             if (Objects.equals(o1, o2)) {
                 return 0;
@@ -428,43 +437,77 @@ public class ElasticSearchProvider implements SearchProvider, ElasticIndexServic
         });
 
         final String indexName = elasticIndex.getIndexName();
-        final GetFieldMappingRequest request = GetFieldMappingRequest.of(r -> r
+        final GetMappingRequest request = GetMappingRequest.of(r -> r
                 .expandWildcards(ExpandWildcard.Open)
-                .index(indexName)
-                .fields("*"));
+                .index(indexName));
 
         try {
-            final GetFieldMappingResponse response = elasticClient.indices().getFieldMapping(request);
-            final Map<String, TypeFieldMappings> allMappings = response.fieldMappings();
+            final GetMappingResponse response = elasticClient.indices().getMapping(request);
 
-            // Build a list of all multi fields (i.e. those defined only in the field mapping).
-            // These are excluded from the fields the user can pick via the Stroom UI, as they are not part
-            // of the returned `_source` field.
-            final Set<String> multiFieldMappings = new HashSet<>();
-            allMappings.values().forEach(indexMappings -> indexMappings.mappings().forEach((fieldName, mapping) -> {
-                final Property source = mapping.mapping().get(fieldName);
-                if (source != null && source._get() instanceof final PropertyBase propertyBase) {
-                    final Map<String, Property> multiFields = propertyBase.fields();
-
-                    if (!multiFields.isEmpty()) {
-                        multiFields.forEach((multiFieldName, multiFieldMapping) -> {
-                            final String fullName = mapping.fullName() + "." + multiFieldName;
-                            multiFieldMappings.add(fullName);
-                        });
-                    }
+            // The response is keyed by concrete index name (a wildcard or alias may resolve to several).
+            // Flatten across all matched indices, keeping the first definition seen for any given field name.
+            response.mappings().values().forEach(indexMapping -> {
+                final TypeMapping typeMapping = indexMapping.mappings();
+                if (typeMapping != null && typeMapping.properties() != null) {
+                    typeMapping.properties().forEach((fieldName, property) ->
+                            registerField(fieldName, property, mappings));
                 }
-            }));
-
-            allMappings.values().forEach(indexMappings -> indexMappings.mappings().forEach((fieldName, mapping) -> {
-                if (!mappings.containsKey(fieldName) && !multiFieldMappings.contains(mapping.fullName())) {
-                    mappings.put(fieldName, mapping);
-                }
-            }));
+            });
         } catch (final IOException e) {
             LOGGER.error(e::getMessage, e);
         }
 
         return mappings;
+    }
+
+    /**
+     * Registers a field and, if it is an {@code object} or {@code nested} container, recursively registers
+     * each of its descendant fields under their full dotted path.
+     * <p>
+     * Container fields are retained (rather than merely descended into) so that their native type stays
+     * discoverable downstream; this is what allows {@code nested} containers such as {@code user} and
+     * {@code user.address} to be identified when a query targets a deeply nested field like
+     * {@code user.address.city}. Container types that are not usable as data source fields (e.g. plain
+     * {@code object}) are filtered out later during native type resolution.
+     *
+     * @param fullName the full (dot-delimited) name of the field
+     * @param property the field's mapping property
+     * @param out      the accumulating map of field name to field mapping
+     */
+    private static void registerField(final String fullName,
+                                      final Property property,
+                                      final NavigableMap<String, FieldMapping> out) {
+        // The synthesised FieldMapping only needs to carry the property; every downstream reader (type
+        // resolution, alias lookup, indexed detection) reads the mapping value, not its key.
+        out.putIfAbsent(fullName, FieldMapping.of(fm -> fm
+                .fullName(fullName)
+                .mapping(leafName(fullName), property)));
+
+        // Recurse into the children of object / nested containers, expanding each to its full dotted path.
+        // Multi-fields (Property.fields(), e.g. `title.keyword`) are deliberately NOT traversed: they are
+        // not part of the returned `_source` and must not be selectable by the user.
+        getChildProperties(property).forEach((childLeafName, childProperty) ->
+                registerField(fullName + FIELD_PATH_SEPARATOR + childLeafName, childProperty, out));
+    }
+
+    /**
+     * @return the child properties of an {@code object} or {@code nested} container, or an empty map for any
+     * other property type (leaf fields, aliases, etc.).
+     */
+    private static Map<String, Property> getChildProperties(final Property property) {
+        if (property.isNested()) {
+            return property.nested().properties();
+        } else if (property.isObject()) {
+            return property.object().properties();
+        }
+        return Map.of();
+    }
+
+    private static String leafName(final String fullName) {
+        final int idx = fullName.lastIndexOf(FIELD_PATH_SEPARATOR);
+        return idx < 0
+                ? fullName
+                : fullName.substring(idx + FIELD_PATH_SEPARATOR.length());
     }
 
     @Override

--- a/stroom-search/stroom-search-elastic/src/main/java/stroom/search/elastic/search/ElasticSearchTaskHandler.java
+++ b/stroom-search/stroom-search-elastic/src/main/java/stroom/search/elastic/search/ElasticSearchTaskHandler.java
@@ -68,8 +68,8 @@ import dev.langchain4j.rag.content.aggregator.ReRankingContentAggregator;
 import dev.langchain4j.rag.query.Query;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
-import jakarta.json.JsonArray;
 import jakarta.json.JsonNumber;
+import jakarta.json.JsonObject;
 import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
 import tools.jackson.databind.node.ObjectNode;
@@ -95,6 +95,7 @@ public class ElasticSearchTaskHandler {
     private static final LambdaLogger LOGGER = LambdaLoggerFactory.getLogger(ElasticSearchTaskHandler.class);
     private static final String RERANK_SCORE_FIELD_NAME = "Rerank Score";
     private static final Pattern RERANK_VECTOR_FIELD_NAME_PATTERN = Pattern.compile("^(.+)\\.[^.]+$");
+    private static final char FIELD_PATH_SEPARATOR = '.';
     public static final ThreadPool SCROLL_REQUEST_THREAD_POOL =
             new ThreadPoolImpl("Elasticsearch Scroll Request");
 
@@ -377,8 +378,10 @@ public class ElasticSearchTaskHandler {
                             values[insertAt] = ValDouble.create((Float) fieldValue);
                         } else if (fieldValue instanceof Boolean) {
                             values[insertAt] = ValBoolean.create((Boolean) fieldValue);
-                        } else if (fieldValue instanceof ArrayList) {
-                            values[insertAt] = ValString.create(((ArrayList<?>) fieldValue).stream()
+                        } else if (fieldValue instanceof final Collection<?> collectionValue) {
+                            // Multi-valued fields (including values gathered from across nested objects) are
+                            // flattened to a single, comma-delimited string.
+                            values[insertAt] = ValString.create(collectionValue.stream()
                                     .map(Object::toString)
                                     .collect(Collectors.joining(", ")));
                         } else {
@@ -443,10 +446,15 @@ public class ElasticSearchTaskHandler {
                 }
                 for (final Hit<ObjectNode> searchHit : searchHits) {
                     final Map<String, JsonData> mapSearchHit = searchHit.fields();
-                    final JsonData rawFieldValue = mapSearchHit.get(denseVectorTextField);
+                    // The reranker source text may itself live inside a nested object, so resolve it using the
+                    // same nested-aware extraction used for result values rather than a flat map lookup.
+                    final Object rawFieldValue = getFieldValue(mapSearchHit, denseVectorTextField);
                     if (rawFieldValue != null && searchHit.id() != null) {
                         try {
-                            String fieldValue = (String) rawFieldValue.to(ArrayList.class).getFirst();
+                            String fieldValue = firstStringValue(rawFieldValue);
+                            if (fieldValue == null) {
+                                continue;
+                            }
                             if (maxContextWindowTokens > 0) {
                                 // Model context window limit is specified, so truncate the field value to fit
                                 final int charLimit = Math.min(fieldValue.length(), maxContextWindowTokens);
@@ -478,21 +486,172 @@ public class ElasticSearchTaskHandler {
     }
 
     /**
-     * Locate the value of the doc field by its full path
+     * Resolves the value of a field by its full (dot-delimited) path from a single search hit's
+     * {@code fields} response.
+     * <p>
+     * Elasticsearch returns non-nested fields flat, keyed by their full path (e.g.
+     * {@code {"user.name": ["Alice"]}}). Fields that live inside a {@code nested} object are instead
+     * grouped by the nested object they belong to, with the sub-field keys expressed relative to the
+     * nesting path. For a doubly-nested field {@code a.b.c} this looks like:
+     * <pre>
+     *   {
+     *     "a": [
+     *       { "b": [ { "c": ["value"] } ] }
+     *     ]
+     *   }
+     * </pre>
+     * This method handles both shapes, descending through an arbitrary number of nesting levels and
+     * flattening the values collected across sibling nested objects.
+     *
+     * @return {@code null} if the field is absent, a single native value, or a {@link List} of native
+     * values when the field (or the nested objects it spans) yields more than one value.
      */
     private Object getFieldValue(final Map<String, JsonData> searchHitMap, final String fieldName) {
-        if (fieldName == null || !searchHitMap.containsKey(fieldName)) {
+        if (fieldName == null || searchHitMap == null || searchHitMap.isEmpty()) {
             return null;
         }
 
-        final JsonArray docField = searchHitMap.get(fieldName).toJson().asJsonArray();
-        if (docField.size() > 1) {
-            return docField.stream()
-                    .map(this::jsonValueToNative)
-                    .toList();
-        } else {
-            return jsonValueToNative(docField.getFirst());
+        // Fast path: the field was returned flat (not nested), matching the original behaviour and
+        // avoiding any conversion for the common, non-nested case.
+        final JsonData directField = searchHitMap.get(fieldName);
+        if (directField != null) {
+            final List<Object> values = new ArrayList<>();
+            addLeafValues(directField.toJson(), values);
+            return toFieldResult(values);
         }
+
+        // Nested field: values are grouped under the enclosing nested object(s). Build a JSON view of
+        // the top-level fields and descend, splitting the path at each nested boundary.
+        final Map<String, JsonValue> fields = new HashMap<>(searchHitMap.size());
+        searchHitMap.forEach((key, data) -> fields.put(key, data.toJson()));
+
+        final List<Object> values = new ArrayList<>();
+        collectFieldValues(fields, fieldName, values);
+        return toFieldResult(values);
+    }
+
+    /**
+     * Recursively collects the native values for {@code fieldPath} from a map of fields that is either
+     * the top-level hit fields or the contents of a single nested object.
+     */
+    private void collectFieldValues(final Map<String, JsonValue> fields,
+                                    final String fieldPath,
+                                    final List<Object> out) {
+        if (fields == null || fieldPath == null) {
+            return;
+        }
+
+        // The field may be present directly at this level, either because it is a plain (non-nested)
+        // sub-field or because we have reached the leaf of a nested path.
+        final JsonValue direct = fields.get(fieldPath);
+        if (direct != null) {
+            addLeafValues(direct, out);
+            return;
+        }
+
+        // Otherwise the field is grouped inside a nested object. Find the longest ancestor path that is
+        // present as an array of objects, then recurse into each object with the remaining relative path.
+        final int splitAt = findNestedSplit(fields, fieldPath);
+        if (splitAt < 0) {
+            return;
+        }
+
+        final String nestedPath = fieldPath.substring(0, splitAt);
+        final String remainder = fieldPath.substring(splitAt + 1);
+        final JsonValue container = fields.get(nestedPath);
+        for (final JsonValue element : container.asJsonArray()) {
+            if (element.getValueType() == JsonValue.ValueType.OBJECT) {
+                // A JsonObject is a Map<String, JsonValue>, so it can be descended into directly.
+                final JsonObject nestedObject = element.asJsonObject();
+                collectFieldValues(nestedObject, remainder, out);
+            }
+        }
+    }
+
+    /**
+     * Finds the index of the {@code '.'} at which {@code fieldPath} should be split into a nested
+     * container path and a relative remainder. Prefixes are tested longest-first so that nested
+     * containers whose relative name spans plain-object segments (e.g. {@code b.c}) are preferred over
+     * shorter matches.
+     *
+     * @return the split index, or {@code -1} if no nested container prefix is present
+     */
+    private int findNestedSplit(final Map<String, JsonValue> fields, final String fieldPath) {
+        int idx = fieldPath.lastIndexOf(FIELD_PATH_SEPARATOR);
+        while (idx > 0) {
+            final String prefix = fieldPath.substring(0, idx);
+            if (isArrayOfObjects(fields.get(prefix))) {
+                return idx;
+            }
+            idx = fieldPath.lastIndexOf(FIELD_PATH_SEPARATOR, idx - 1);
+        }
+        return -1;
+    }
+
+    /**
+     * @return true if the value is a non-empty array containing at least one object (the shape used by
+     * Elasticsearch to group the values of a {@code nested} field).
+     */
+    private boolean isArrayOfObjects(final JsonValue value) {
+        if (value == null || value.getValueType() != JsonValue.ValueType.ARRAY) {
+            return false;
+        }
+        return value.asJsonArray().stream()
+                .anyMatch(element -> element.getValueType() == JsonValue.ValueType.OBJECT);
+    }
+
+    /**
+     * Adds the native representation of a leaf field's value(s) to {@code out}. Elasticsearch always
+     * returns field values as an array, but this also tolerates a bare scalar defensively.
+     */
+    private void addLeafValues(final JsonValue value, final List<Object> out) {
+        if (value == null) {
+            return;
+        }
+
+        if (value.getValueType() == JsonValue.ValueType.ARRAY) {
+            for (final JsonValue element : value.asJsonArray()) {
+                final Object nativeValue = jsonValueToNative(element);
+                if (nativeValue != null) {
+                    out.add(nativeValue);
+                }
+            }
+        } else {
+            final Object nativeValue = jsonValueToNative(value);
+            if (nativeValue != null) {
+                out.add(nativeValue);
+            }
+        }
+    }
+
+    /**
+     * Collapses the collected values into the shape expected by the caller: {@code null} for no values,
+     * the single value, or the list itself for multiple values.
+     */
+    private Object toFieldResult(final List<Object> values) {
+        if (values.isEmpty()) {
+            return null;
+        } else if (values.size() == 1) {
+            return values.getFirst();
+        } else {
+            return values;
+        }
+    }
+
+    /**
+     * Returns the first value of a resolved field as a String, whether the field yielded a single value
+     * or a list of values.
+     */
+    private String firstStringValue(final Object fieldValue) {
+        if (fieldValue == null) {
+            return null;
+        }
+        if (fieldValue instanceof final Collection<?> collection) {
+            return collection.isEmpty()
+                    ? null
+                    : String.valueOf(collection.iterator().next());
+        }
+        return String.valueOf(fieldValue);
     }
 
     private Object jsonValueToNative(final JsonValue jsonValue) {

--- a/stroom-search/stroom-search-elastic/src/main/java/stroom/search/elastic/search/SearchExpressionQueryBuilder.java
+++ b/stroom-search/stroom-search-elastic/src/main/java/stroom/search/elastic/search/SearchExpressionQueryBuilder.java
@@ -46,7 +46,9 @@ import dev.langchain4j.model.embedding.EmbeddingModel;
 import jakarta.inject.Provider;
 
 import java.net.InetAddress;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.BiFunction;
@@ -60,6 +62,8 @@ import java.util.stream.Stream;
 public class SearchExpressionQueryBuilder {
 
     private static final String DELIMITER = ",";
+    private static final String FIELD_PATH_SEPARATOR = ".";
+    private static final Pattern FIELD_PATH_SPLIT_PATTERN = Pattern.compile("\\.");
     private static final Pattern WILDCARD_PATTERN = Pattern.compile(".*[*?].*");
     private static final Pattern QUOTED_PATTERN = Pattern.compile("^\"(.+)\"$");
     private static final Pattern IPV4_ADDRESS_PATTERN =
@@ -153,6 +157,11 @@ public class SearchExpressionQueryBuilder {
         }
         final String fieldName = elasticIndexField.getFldName();
 
+        // Resolve the ordered list of `nested` object paths (outermost first) that this field lives
+        // under. This is computed once per term and threaded through query construction so that the
+        // leaf query can be wrapped in one Elasticsearch `nested` query per level of nesting.
+        final List<String> nestedPaths = getNestedPaths(fieldName);
+
         // Validate the expression
         if (value == null || value.isEmpty()) {
             return null;
@@ -166,11 +175,9 @@ public class SearchExpressionQueryBuilder {
         // Special case: if the expression is a wildcard, use the `exists` query
         if (value.equals("*")) {
             if (Condition.EQUALS.equals(condition)) {
-                return QueryBuilders.exists(q -> q.field(fieldName));
+                return wrapInNested(nestedPaths, QueryBuilders.exists(q -> q.field(fieldName)));
             } else if (Condition.NOT_EQUALS.equals(condition)) {
-                return QueryBuilders.bool()
-                        .mustNot(QueryBuilders.exists(q -> q.field(fieldName)))
-                        .build()._toQuery();
+                return negate(wrapInNested(nestedPaths, QueryBuilders.exists(q -> q.field(fieldName))));
             }
         }
 
@@ -179,17 +186,22 @@ public class SearchExpressionQueryBuilder {
         if (elasticFieldType.equals(FieldType.ID) ||
             elasticFieldType.equals(FieldType.LONG) ||
             elasticFieldType.equals(FieldType.INTEGER)) {
-            return buildScalarQuery(condition, elasticIndexField, fieldName, value, this::getNumber, docRef);
+            return buildScalarQuery(
+                    condition, elasticIndexField, fieldName, nestedPaths, value, this::getNumber, docRef);
         } else if (elasticFieldType.equals(FieldType.FLOAT)) {
-            return buildScalarQuery(condition, elasticIndexField, fieldName, value, this::getFloat, docRef);
+            return buildScalarQuery(
+                    condition, elasticIndexField, fieldName, nestedPaths, value, this::getFloat, docRef);
         } else if (elasticFieldType.equals(FieldType.DOUBLE)) {
-            return buildScalarQuery(condition, elasticIndexField, fieldName, value, this::getDouble, docRef);
+            return buildScalarQuery(
+                    condition, elasticIndexField, fieldName, nestedPaths, value, this::getDouble, docRef);
         } else if (elasticFieldType.equals(FieldType.DATE)) {
-            return buildScalarQuery(condition, elasticIndexField, fieldName, value, this::getDate, docRef);
+            return buildScalarQuery(
+                    condition, elasticIndexField, fieldName, nestedPaths, value, this::getDate, docRef);
         } else if (elasticFieldType.equals(FieldType.IPV4_ADDRESS)) {
-            return buildScalarQuery(condition, elasticIndexField, fieldName, value, this::getIpV4Address, docRef);
+            return buildScalarQuery(
+                    condition, elasticIndexField, fieldName, nestedPaths, value, this::getIpV4Address, docRef);
         } else {
-            return buildStringQuery(condition, value, docRef, elasticIndexField, fieldName);
+            return buildStringQuery(condition, value, docRef, elasticIndexField, fieldName, nestedPaths);
         }
     }
 
@@ -197,7 +209,8 @@ public class SearchExpressionQueryBuilder {
                                    final String expression,
                                    final DocRef docRef,
                                    final ElasticIndexField indexField,
-                                   final String fieldName) {
+                                   final String fieldName,
+                                   final List<String> nestedPaths) {
         final List<String> terms = tokenizeExpression(expression).filter(term -> !term.isEmpty()).toList();
         if (terms.isEmpty()) {
             return null;
@@ -217,30 +230,32 @@ public class SearchExpressionQueryBuilder {
 
         switch (condition) {
             case EQUALS -> {
-                return buildQueryFn.apply(fieldName, expression);
+                return wrapInNested(nestedPaths, buildQueryFn.apply(fieldName, expression));
             }
             case NOT_EQUALS -> {
-                return negate(buildQueryFn.apply(fieldName, expression));
+                return negate(wrapInNested(nestedPaths, buildQueryFn.apply(fieldName, expression)));
             }
             case MATCHES_REGEX -> {
-                return QueryBuilders.regexp(q -> q
+                return wrapInNested(nestedPaths, QueryBuilders.regexp(q -> q
                         .field(fieldName)
                         .value(expression)
-                );
+                ));
             }
             case IN -> {
+                final Query inQuery;
                 if (terms.size() > 1) {
-                    return BoolQuery.of(q -> q
+                    inQuery = BoolQuery.of(q -> q
                             .should(terms.stream()
                                     .map(term -> buildQueryFn.apply(fieldName, term))
                                     .toList())
                     )._toQuery();
                 } else {
-                    return buildQueryFn.apply(fieldName, expression);
+                    inQuery = buildQueryFn.apply(fieldName, expression);
                 }
+                return wrapInNested(nestedPaths, inQuery);
             }
             case IN_DICTIONARY -> {
-                return buildDictionaryQuery(condition, fieldName, docRef, indexField);
+                return buildDictionaryQuery(condition, fieldName, docRef, indexField, nestedPaths);
             }
             default -> throw new UnsupportedOperationException(
                     "Unsupported condition '" + condition.getDisplayValue() + "' for " + indexField.getDisplayValue() +
@@ -307,6 +322,7 @@ public class SearchExpressionQueryBuilder {
             final ExpressionTerm.Condition condition,
             final ElasticIndexField indexField,
             final String fieldName,
+            final List<String> nestedPaths,
             final String rawValue,
             final TriFunction<Condition, String, String, FieldValue> valueParser,
             final DocRef docRef
@@ -317,58 +333,58 @@ public class SearchExpressionQueryBuilder {
         switch (condition) {
             case EQUALS -> {
                 fieldValue = valueParser.apply(condition, fieldName, rawValue);
-                return QueryBuilders
-                        .term(q -> q
-                                .field(fieldName)
-                                .value(fieldValue));
-            }
-            case NOT_EQUALS -> {
-                fieldValue = valueParser.apply(condition, fieldName, rawValue);
-                return negate(QueryBuilders
+                return wrapInNested(nestedPaths, QueryBuilders
                         .term(q -> q
                                 .field(fieldName)
                                 .value(fieldValue)));
+            }
+            case NOT_EQUALS -> {
+                fieldValue = valueParser.apply(condition, fieldName, rawValue);
+                return negate(wrapInNested(nestedPaths, QueryBuilders
+                        .term(q -> q
+                                .field(fieldName)
+                                .value(fieldValue))));
             }
             case IN -> {
                 fieldValues = tokenizeExpression(rawValue)
                         .map(val -> valueParser.apply(condition, fieldName, val))
                         .toList();
-                return QueryBuilders
+                return wrapInNested(nestedPaths, QueryBuilders
                         .terms(q -> q
                                 .field(fieldName)
-                                .terms(t -> t.value(fieldValues)));
+                                .terms(t -> t.value(fieldValues))));
             }
             case GREATER_THAN -> {
                 fieldValue = valueParser.apply(condition, fieldName, rawValue);
-                return QueryBuilders
+                return wrapInNested(nestedPaths, QueryBuilders
                         .range(q -> q.untyped(UntypedRangeQuery.of(r -> r
                                 .field(fieldName)
                                 .gt(JsonData.of(fieldValue)))
-                        ));
+                        )));
             }
             case GREATER_THAN_OR_EQUAL_TO -> {
                 fieldValue = valueParser.apply(condition, fieldName, rawValue);
-                return QueryBuilders
+                return wrapInNested(nestedPaths, QueryBuilders
                         .range(q -> q.untyped(UntypedRangeQuery.of(r -> r
                                 .field(fieldName)
                                 .gte(JsonData.of(fieldValue)))
-                        ));
+                        )));
             }
             case LESS_THAN -> {
                 fieldValue = valueParser.apply(condition, fieldName, rawValue);
-                return QueryBuilders
+                return wrapInNested(nestedPaths, QueryBuilders
                         .range(q -> q.untyped(UntypedRangeQuery.of(r -> r
                                 .field(fieldName)
                                 .lt(JsonData.of(fieldValue)))
-                        ));
+                        )));
             }
             case LESS_THAN_OR_EQUAL_TO -> {
                 fieldValue = valueParser.apply(condition, fieldName, rawValue);
-                return QueryBuilders
+                return wrapInNested(nestedPaths, QueryBuilders
                         .range(q -> q.untyped(UntypedRangeQuery.of(r -> r
                                 .field(fieldName)
                                 .lte(JsonData.of(fieldValue)))
-                        ));
+                        )));
             }
             case BETWEEN -> {
                 fieldValues = tokenizeExpression(rawValue)
@@ -378,15 +394,15 @@ public class SearchExpressionQueryBuilder {
                     throw new IllegalArgumentException(
                             "Two values needed for between query. Only " + fieldValues.size() + " provided");
                 }
-                return QueryBuilders
+                return wrapInNested(nestedPaths, QueryBuilders
                         .range(q -> q.untyped(UntypedRangeQuery.of(r -> r
                                 .field(fieldName)
                                 .gte(JsonData.of(fieldValues.get(0)))
                                 .lte(JsonData.of(fieldValues.get(1))))
-                        ));
+                        )));
             }
             case IN_DICTIONARY -> {
-                return buildDictionaryQuery(condition, fieldName, docRef, indexField);
+                return buildDictionaryQuery(condition, fieldName, docRef, indexField, nestedPaths);
             }
             default -> throw new SearchException("Unexpected condition '" + condition.getDisplayValue() + "' for " +
                                                  indexField.getFldType().getDisplayValue() + " field type");
@@ -399,6 +415,98 @@ public class SearchExpressionQueryBuilder {
                 .should(MatchAllQuery.of(q -> q)._toQuery())
                 .mustNot(query)
                 .build()._toQuery();
+    }
+
+    /**
+     * Determines the ordered list of Elasticsearch `nested` object paths that a field lives under,
+     * from outermost to innermost.
+     * <p>
+     * For a field {@code a.b.c.d} where {@code a}, {@code a.b} and {@code a.b.c} are all mapped as
+     * `nested` types, this returns {@code [a, a.b, a.b.c]}. Only the ancestor path segments are
+     * inspected (the leaf segment {@code d} is the scalar/text field being queried and is never a
+     * nesting level itself). Ancestors that are not mapped as `nested` (for example plain `object`
+     * fields, which do not require a nested query) are skipped.
+     *
+     * @param fieldName the fully qualified (dot-delimited) field name
+     * @return the nesting paths in outermost-first order, or an empty list if the field is not nested
+     */
+    private List<String> getNestedPaths(final String fieldName) {
+        if (fieldName == null || !fieldName.contains(FIELD_PATH_SEPARATOR)) {
+            return Collections.emptyList();
+        }
+
+        final String[] segments = FIELD_PATH_SPLIT_PATTERN.split(fieldName);
+        final List<String> nestedPaths = new ArrayList<>();
+        final StringBuilder pathBuilder = new StringBuilder();
+
+        // Inspect each ancestor path (i.e. every prefix except the leaf field itself) and collect
+        // those that are mapped as `nested`. This naturally supports arbitrarily deep nesting.
+        for (int i = 0; i < segments.length - 1; i++) {
+            if (i > 0) {
+                pathBuilder.append(FIELD_PATH_SEPARATOR);
+            }
+            pathBuilder.append(segments[i]);
+
+            final String path = pathBuilder.toString();
+            if (isNestedField(path)) {
+                nestedPaths.add(path);
+            }
+        }
+
+        return nestedPaths;
+    }
+
+    /**
+     * @return true if the field at the given path is mapped in Elasticsearch as a `nested` type.
+     */
+    private boolean isNestedField(final String path) {
+        final IndexField indexField = indexFieldCache.get(indexDoc.asDocRef(), path);
+        return indexField instanceof final ElasticIndexField elasticIndexField &&
+               Kind.Nested.jsonValue().equals(elasticIndexField.getNativeType());
+    }
+
+    /**
+     * Convenience overload that resolves the nesting paths for the given field and wraps the query.
+     *
+     * @see #wrapInNested(List, Query)
+     */
+    private Query wrapInNested(final String fieldName, final Query query) {
+        return wrapInNested(getNestedPaths(fieldName), query);
+    }
+
+    /**
+     * Wraps a leaf query in one Elasticsearch `nested` query per level of nesting the field is
+     * subject to, supporting arbitrarily deep nesting by chaining `nested` queries.
+     * <p>
+     * Given nesting paths {@code [a, a.b]} and a leaf query {@code Q}, this produces:
+     * <pre>
+     *   nested(path=a, query=
+     *       nested(path=a.b, query=Q))
+     * </pre>
+     * The paths are supplied outermost-first, so wrapping is applied from the innermost path
+     * outwards to preserve that structure. If the field is not nested, the leaf query is returned
+     * unchanged, keeping behaviour identical for non-nested fields.
+     *
+     * @param nestedPaths the nesting paths in outermost-first order (see {@link #getNestedPaths})
+     * @param query       the leaf query to wrap
+     * @return the (possibly wrapped) query
+     */
+    private Query wrapInNested(final List<String> nestedPaths, final Query query) {
+        if (nestedPaths == null || nestedPaths.isEmpty()) {
+            return query;
+        }
+
+        Query wrapped = query;
+        // Wrap from the innermost path outwards so that the outermost `nested` query is applied last.
+        for (int i = nestedPaths.size() - 1; i >= 0; i--) {
+            final String path = nestedPaths.get(i);
+            final Query inner = wrapped;
+            wrapped = QueryBuilders.nested(n -> n
+                    .path(path)
+                    .query(inner));
+        }
+
+        return wrapped;
     }
 
     /**
@@ -487,12 +595,17 @@ public class SearchExpressionQueryBuilder {
 
     /**
      * Loads the specified Dictionary from the doc store. Each line is combined with AND logic.
+     * <p>
+     * When the field is nested, the resulting combined query is wrapped in the appropriate chain of
+     * `nested` queries. All lines target the same field (and therefore the same nesting paths), so a
+     * single outer wrap is applied to the combined query.
      */
     private Query buildDictionaryQuery(
             final Condition condition,
             final String fieldName,
             final DocRef docRef,
-            final ElasticIndexField indexField
+            final ElasticIndexField indexField,
+            final List<String> nestedPaths
     ) {
         final String[] lines = wordListProvider.getWords(docRef);
         final BoolQuery.Builder builder = new BoolQuery.Builder();
@@ -532,7 +645,7 @@ public class SearchExpressionQueryBuilder {
             builder.should(mustQueries.build()._toQuery());
         }
 
-        return builder.build()._toQuery();
+        return wrapInNested(nestedPaths, builder.build()._toQuery());
     }
 
     private boolean operatorHasChildren(final ExpressionOperator operator) {

--- a/unreleased_changes/20260711_083803_157__5652.md
+++ b/unreleased_changes/20260711_083803_157__5652.md
@@ -1,0 +1,68 @@
+* Feature **#5652** : Support Elasticsearch nested field types in search.
+
+
+```sh
+# ********************************************************************************
+# Issue number: 5652
+# Issue title:  Support Elasticsearch `nested` field mappings in search
+# Issue tags:   
+# Issue link:   https://github.com/gchq/stroom/issues/5652
+# ********************************************************************************
+
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Bug **#123** : Fix bug with an associated GitHub issue in this repository.
+#
+# * Bug **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository.
+#
+# * Feature **#789** : Add new feature X.
+#
+# * Bug : Fix bug with no associated GitHub issue.
+#
+#
+# Note: The line must start '* XXX ', where 'XXX' is a valid category,
+#       one of [Bug Feature Refactor Dependency Build].
+
+
+# --------------------------------------------------------------------------------
+# The following is random text to make this file unique for git's change detection
+# CaqC1jvVn4nZT2fRjG5wd2fjPmUYLvWjwlTz1KLKqWX86m7EFbluDcU3HRSaj0MdW9AguDiMVPfTgNqY
+# ofZz9NxM4ZWwSh7kyv3i1yAFr7IPOjIOFklOUk4mS6yieiPrlnuwSPwPZ6BFb1zrhb4RRLbcJy8zQFqe
+# 8ORt1r9XFsLYoH7DYkACkPZthosVXccLdUOdzXXbpddKcpcZtEWSxRtb4QlB5yFS5lqVTO1Pd45RW7uX
+# OCyPc0Vg1KiJgVo6D9UAooWkTGbyQECCFJaa4F50yulJTZPxZ5WYeYPlP9Gr95NJSGh0kmiZorzqXuy9
+# fp3AbsufOCR0bjK5wlbvepLBF5uGw63ZC4q93m0va0VilOnjisKiVhX7ZvxCCbIMbQQewxVNo6YggTnz
+# mBA90O06K9jdmfbrTVEXt8GcakumI7z9QCoad4lf9vfT7xp0GjGxqSoPEOsfGP4TvZWJCWou8iiTi10p
+# 7emjs5Ioc358Z2lEr3ciyrQDfXAgPArItNIuSw8Oyvbo6YrXsAtVPrDfsfETjiu6W5syM230sqO8tgRj
+# PGwV8onsHy5w4lFd15CmuwV5r6CKm4jSYe4VaAMmOCsUUBRO55HglQ9f8WWhNu60Ll0f69FH4ZMTP9qO
+# J9IywRt5u0nNqjGbBiFx0J0NmUUmUmXXkKAGrE4pcJmdBUlCYFFg7Tn6IX7WauP5fzHtWjz4xZUmlC0h
+# Ovm1H0nebLtgFISVw0IIFbb82icbmZGLn5n5VASj51HECRw2L9Wo3MOk4QMEAS11m8esdCVPNNBsK7eW
+# nf7FgB3dnkIBQzHpFhLXhzxmAuJHaYuIgIwV8BqNEZn0tF4dEpStAVQ2B4OeEgUBMIWwAhWRv0FxtRwl
+# L9hMFinLCJFwHuujxEaPxOlVDzU7fUeOMcQ8Q4foPMNp2d9EufH5qnOGI0K9m9aFPvhgKNAzMaaWBaLe
+# Czez8qJi8QqTJYx11WKdTdswECBthzZMac6swQAGmEQRWOmSGgPEKIjLOVZH7WQhn0ZqfuQvEO5VEZiM
+# Q3XTt9Id31XyyUzS60DyUFZrv5Ok77qMaxGsjJiymQcQTuo8UFcN1sv6utsPMzAEo2vM7gfNfxysHtNn
+# X3vH1mdrDnPPXKbOD7T1WZhmGMiQGL6YnYUq0NqoTgU5KWosVqWEERlB2suhXPGfpwCi9L9ZJvftzNkb
+# wgRbW5hZKL8mtvZvZWg4myi7x6LqkxYsciFM42LxSsEbTjXKafO2urtBwMhyMdMyMB43WAjLUdSnxTeG
+# gplKqWm53aMenbeNun1YaZQkLl34wq1504Upc33l0jIicCvNyvpwkkv92T7bHXwh9kLdjmulEVTbasme
+# PE6XwxSWjdHtL3p9AzP4EnNucyTbMLepGGwwMXsgRNuJkfkSTtwvqDGF7Lf7f4bWH7Z50SJVbb9vA58h
+# NKsXiCcRRQCQlbJL0FRyi5UNRNGsQRE8YOrSDZa6EZfF7zxuVvkeLU5HzxHaPQeAGDsjVOZ6wy7zGI66
+# OfIPv1a1GOwxiAxH4zAK1Kj5nJnFSP0QB76BKVqH3oPPRjkfCzGnjTIjMNbUAu9tPZVvKJTE9mJ6LvVW
+# HMIBRWPXrBfPEXFjnOO50kajW8jVThBqB7VFgmyDgNJLdtS8PC0sJjrmMWdYE11Sbr81t20iGgLFHcUn
+# RcEl18b9Lqg7M0qAzL5a3wCvM4nXGpEOawfmgb2HkuYU8TCarCHg7krQeqFyk5RJ2poOdmZTEln8jKPL
+# nt1f9g54qKm49mcUE5XU91PgxpSwBUT3x2FoSpEKw6yrijKXDkpIQE9Ust5L1GFHfEIDo3V9XRWcXf0W
+# iGUdmd3OKOqB33oC7DQdRJs0Z2ZcyQeHGOPQp4sIfIDFKL76SRGM7pbbKKJWMajIAzY07iVYxsUoB7gd
+# gS248hLK3KHySAOWFfxadnREVBer6dTT77DOr0u6YufHiq07bWmpxSiRulK7NJsPwlOl0JI9Cy5gUBAL
+# VyF8rRqf8xmHz9gHtlvWhhFJPqWIVZZr0eNcHDYQOVWqBIXyNYyfptdBuef8vK9XktAEWQKGNlypqZHd
+# 6IHoIK67B1XDKSo2lxHVg2OYJdwu897QUJFfHhAYWg7wl4SwHoKRvra01esWYpGl5ucFxSm4dBDBsMCf
+# kEUnzAHIDSsPUTs6zRL0FHIknBjRUMruEa3yN8GmKwHfqqHMOmY4T687H5UBQzQFsxEaWClsKP2nY7de
+# dDdj6kjtT7uNnEefKXe9tLdV1qHKz1ALhM6Rdm2097brN98A5prSByUuF6pVk3TxiEh0Q2OiNxQMFcqP
+# UqRShzgOrhSVoXEl1szZyGOXgL1dpsNJcKhw6SSUlnRQpBP3ZalQNrr2dz7PmoPS4bDf7gEaThwS00bS
+# --------------------------------------------------------------------------------
+
+```


### PR DESCRIPTION
Closes #5652.

This change makes the Stroom Elasticsearch implementation more useful as a knowledge retrieval engine, for the reasons explained in the issue. The result is increased vector search accuracy for large textual data.

This change does not change Lucene supported field types, as `nested` fields are an Elasticsearch-specific concept.