### PR TITLE
Map verifyHostname in HttpClientConfigConverter

### DIFF
--- a/stroom-util/src/main/java/stroom/util/http/HttpClientConfigConverter.java
+++ b/stroom-util/src/main/java/stroom/util/http/HttpClientConfigConverter.java
@@ -165,6 +165,7 @@ public class HttpClientConfigConverter {
             out.setTrustStoreType(convert(in.getTrustStoreType(), String.class));
             out.setTrustStoreProvider(convert(in.getTrustStoreProvider(), String.class));
             out.setTrustSelfSignedCertificates(convert(in.isTrustSelfSignedCertificates(), boolean.class));
+            out.setVerifyHostname(convert(in.isVerifyHostname(), boolean.class));
             out.setSupportedCiphers(convertList(in.getSupportedCiphers(), String.class));
             out.setSupportedProtocols(convertList(in.getSupportedProtocols(), String.class));
             out.setCertAlias(convert(in.getCertAlias(), String.class));
@@ -185,6 +186,7 @@ public class HttpClientConfigConverter {
                         .trustStoreType(convert(in.getTrustStoreType(), String.class))
                         .trustStoreProvider(convert(in.getTrustStoreProvider(), String.class))
                         .trustSelfSignedCertificates(convert(in.isTrustSelfSignedCertificates(), boolean.class))
+                        .verifyHostname(convert(in.isVerifyHostname(), boolean.class))
                         .supportedCiphers(convertList(in.getSupportedCiphers(), String.class))
                         .supportedProtocols(convertList(in.getSupportedProtocols(), String.class))
                         .certAlias(convert(in.getCertAlias(), String.class))

--- a/stroom-util/src/test/java/stroom/util/http/TestHttpClientConfigConverter.java
+++ b/stroom-util/src/test/java/stroom/util/http/TestHttpClientConfigConverter.java
@@ -52,4 +52,21 @@ class TestHttpClientConfigConverter {
 
         assertThat(httpClientConfiguration).isEqualTo(reverse);
     }
+
+    @Test
+    void testVerifyHostname() {
+        final PathCreator pathCreator = new TemporaryPathCreator();
+        final HttpClientConfigConverter restClientConfigConverter = new HttpClientConfigConverter(pathCreator);
+
+        final HttpTlsConfiguration in = HttpTlsConfiguration
+                .builder()
+                .verifyHostname(false)
+                .build();
+
+        final io.dropwizard.client.ssl.TlsConfiguration out = restClientConfigConverter.convert(
+                in,
+                io.dropwizard.client.ssl.TlsConfiguration.class);
+
+        assertThat(out.isVerifyHostname()).isFalse();
+    }
 }

--- a/unreleased_changes/20260725_222653_845__5669.md
+++ b/unreleased_changes/20260725_222653_845__5669.md
@@ -1,0 +1,69 @@
+* Bug **#5669** : Fix `HttpClientConfigConverter` not mapping `verifyHostname`, which prevented TLS hostname verification being disabled on HTTP clients.
+
+
+```sh
+# ********************************************************************************
+# Issue number: 5669
+# Issue title:  HttpClientConfigConverter does not map verifyHostname
+# Issue link:   https://github.com/gchq/stroom/issues/5669
+# ********************************************************************************
+
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Bug **#123** : Fix bug with an associated GitHub issue in this repository.
+#
+# * Bug **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository.
+#
+# * Feature **#789** : Add new feature X.
+#
+# * Bug : Fix bug with no associated GitHub issue.
+#
+#
+# Note: The line must start '* XXX ', where 'XXX' is a valid category,
+#       one of [Bug Feature Refactor Dependency Build].
+
+
+# --------------------------------------------------------------------------------
+# The following is random text to make this file unique for git's change detection
+# qwVQ3OW93s1QTQUlOXdHsk80IijQu2c6cj4SsD6tyBpM8XIbuoRgVD0HfGEw60j3kuAfqudK56viwRt9
+# y6vlOIhwdLwJTOqjJLy0uJHseiMAfpbvJcXtnkMB5LCAn7vfvB73zHo9UwWXHjBKpzas9BwuAxkdrunq
+# JKccSyR05xj3s3s5R2iudBDhS0DO4Cdw0Mse8gQZza9rlBJ7lv6NosjeMN8B1aN424EXIz75UVlz5fK9
+# lBEtFJ0oibCmSP53uyDBDtepZRWd9f4b7tdMRJ55p2VC16jmwagWqBrD42VhgMbkfia7l7pR8gEpP1Su
+# hWEeRj9AoEFFljkzJ8Y6oYkl1IWtvcLTExWl8Y5dNCBLa4wNeB2yAcXTozWXLvUxbnphQ1agJhHaPjtu
+# kOzzddtrKeGgsvgyyQfpAEFBZAMDMuAD7SJYO8TzpjLw8ZfYRpA5uD3SJCG46ze3cOzvRU2Bbf5DFUSP
+# dAgmvdYunZG2N0dEKv9m896jvcCxiAPExSA7TLu4xtLKLtqsrDtYKIrRsOAvQl7j3CPfQ3lBK8xjpPqZ
+# jODv37tvWis2QdWnGYXnMGyY09M4vcVVqVkoKH2ryRmNxEYxu5DbTf6roF3hpJE67Z1jxg0UGrEACrTW
+# RuEfAkOIwJP7gGNzc2ziwVZs2mJbwugPBr03zvUVht1vEgA3Bq2mnYjGGQKCxqj3l3Ygji6yfBo77kRy
+# 3lopeKJTR5GLUju0bMsP11HIrAvAFg4FVPtPnDkly5M9g9MggRNkK5hijGu35fuJrAbA6f6rhoUICa2B
+# CR6ASk8Y0ZONSNDhUuxaHHnDxUE55dXLTTVNOdSVkjQYnkXJyPL58CKp2vK3CrlZv6R8DPUQLjmkHaBd
+# vZRgVqHTbXfUOySepiXHYknEPCEhY19i87o8PfEP289GBLaf2b45cMMmWNmqHcujTZx573l9qcV5ugox
+# F2kADMKcONkKDRPXFSHC8sTONtgzRhWOvJ3MZ0JG8QQm6NX5QZ1Fs5X9oON5CVC7AKEy2BYyqy4ArrvN
+# qzjEycuVbXDZQeDiPNd6J8V1bW65iXRT3oEBTapkGlgqCGD43XUHfK6VFbUyrTKKMsjcWr8gVzEs6Kgt
+# 3cYWIoBekW3ufArk3udMuoRxyk5WaoGhSqTmMmVAHDJs5LQDOB3X9d8oqKi9ttDXoL9Qejoi2rip7Hz3
+# zMkIVNJFT0uAb1mrl0vtuuvtDAJgCyjuCFg4LjH3PPNLff1U5Skc2oI0Bm4twTbpRJnnuQdeOim1GKHC
+# FzyBCx8QWMJdWhWDhyNGuxUlhD4sWRZ0rPozs3ga1WtQkUC5yMh2uCpEYhHQzMqx2LBD1Aqp1gdeZOuw
+# Qoel6TPoL06PAZui4ydAgzhZ9oIEbdHOHFoAPC9rUbonk4mc1IIQrQWVbxUu77SXxifiLfaA3OExzayh
+# dzI758hMQAKagE6lUo08fGRBB4bm18O1cBzz7VkQANVT4uciB6sSM8Bpb4Sk3nsOtNilpXlKzNSM5F1r
+# a7NMWaf1Sg5Obnss5nhy1cbWGxhaUsaz3VutEsWmTpCOMDMfMWaesoL9LJzDCbh16OfJhdp7brpc4vXD
+# bsywsZnLiQ7RHd6a4bM1a5oZE5ku6XGcA1arpieyIJVTEeK2MIwxCdEH5Exek6MNGcR3jNDvVlOooNkA
+# YSIvbByJ3LXVWse6B7bJhrgDSBcKJ9rvvPMyQma9iCaquPGtMDskrJuVFgiFja81W79VPftclf9GE0Ta
+# cnaI68sx5U0Mtt5oYBnQMHkukI1VRgjcPCn4mKqDbTtllOuOI5aOW3IhRAlysZ4tmyOq38glOGV0kVFT
+# pLAWxIOpcA8Hwe1IIkEe8rlE0ShLrLxncmHHYhSF16jaB8vZZFB1VpJUneKbxfba1itSyftWrLlrTSsb
+# ME3Su7Z4kqp2ZqWYRE8CAddNFSRClnKeBRlUlT01eDl8LRey9ttE8Xu4PpikivA2h7rczdYa3lvCIHGu
+# fWoHyASkaEks244BiL8OSbLmL3EOdVZXpjZojA870qOd2wgJqFqp4rd5jIdRBzWHqnrUtBiAZ72cO91b
+# IA0zCPd995UWO2E54xnlTfBL4UdIT2m5nWsdcjcVFZi9BHNsPdasvYj7qJR6ErpsOnpCYOYmcOw90vVg
+# NFOUFhtOKDGTFlBdODDsNuoisb2GFrHRYZEBOaBpH1VwFOn0UYUv0BagVdOZbraERWx0U0RuI9KnlBJa
+# oeYLjXv2ZgPzNp35A7pTbyiSxheIKz12z15D1koS6ZHBFtUfZxqsBqsQxvoYgjtXt6OpTzk3h7OHqMdd
+# S7yqrAijsBD5hrRBON5B10QI3K7SQwHBAmTKoStVrLgm13DY9kmoCbygty0Bk2iXtIeR13u5qYOoILsK
+# WNMIYLMGFEBPKkdGRKaimb5Md2xSn9OBffBxsBU4YwIvdgeualLv8Tgj4WWyepHFkUDLbObRBKb00JM0
+# WTouUvrV5QEf3w2umigClLQzGF2DldiyHxKnkoJJE3IjJjsjBHjQ9KxXpQI5kfssfBP4cmqg9SCfEoN3
+# --------------------------------------------------------------------------------
+
+```


### PR DESCRIPTION
Fixes #5669.

`verifyHostname` was the only `HttpTlsConfiguration` field not mapped by `HttpClientConfigConverter`, in either direction. The value was dropped and Dropwizard's default of `true` always applied, so hostname verification could not be disabled on any HTTP client configured through Stroom's TLS config — including `forwardHttpDestinations[].httpClient.tls` in stroom-proxy.

The adjacent boolean `trustSelfSignedCertificates` is mapped, which makes the symptom confusing in practice: self-signed trust visibly works while `verifyHostname` appears to be ignored.

### Why the existing test did not catch it

`TestHttpClientConfigConverter.test()` round-trips a populated object and asserts equality. `SampleObjectCreator` populates every `boolean` with `true`, and `DEFAULT_VERIFY_HOSTNAME` is also `true`, so the dropped value coincides with the default on both sides and equality still holds.

The added test converts a `HttpTlsConfiguration` with `verifyHostname(false)` and asserts the non-default value survives. It fails on `master`:

```
TestHttpClientConfigConverter > testVerifyHostname() FAILED
    org.opentest4j.AssertionFailedError:
    Expecting value to be false but was true
```

and passes with the change.

### Changes

- `HttpClientConfigConverter` — map `verifyHostname` in both conversion directions, positioned to match the field order in `HttpTlsConfiguration`.
- `TestHttpClientConfigConverter` — add `testVerifyHostname()`.
- Changelog entry.
