### PR TITLE
Run dir-scanner file ingest as the processing user

### DIFF
--- a/stroom-proxy/stroom-proxy-app/src/main/java/stroom/proxy/app/handler/ZipDirScanner.java
+++ b/stroom-proxy/stroom-proxy-app/src/main/java/stroom/proxy/app/handler/ZipDirScanner.java
@@ -22,6 +22,7 @@ import stroom.meta.api.AttributeMapUtil;
 import stroom.meta.api.StandardHeaderArguments;
 import stroom.proxy.app.DirScannerConfig;
 import stroom.receive.common.ReceiptIdGenerator;
+import stroom.security.api.CommonSecurityContext;
 import stroom.util.concurrent.UniqueId;
 import stroom.util.io.FileUtil;
 import stroom.util.io.PathCreator;
@@ -70,6 +71,7 @@ public class ZipDirScanner {
     private final PathCreator pathCreator;
     private final ZipReceiver zipReceiver;
     private final ReceiptIdGenerator receiptIdGenerator;
+    private final CommonSecurityContext securityContext;
     private final NestedNumberedDirProvider failureDirProvider;
     private final Path failureDir;
 
@@ -77,11 +79,13 @@ public class ZipDirScanner {
     public ZipDirScanner(final Provider<DirScannerConfig> dirScannerConfigProvider,
                          final PathCreator pathCreator,
                          final ZipReceiver zipReceiver,
-                         final ReceiptIdGenerator receiptIdGenerator) {
+                         final ReceiptIdGenerator receiptIdGenerator,
+                         final CommonSecurityContext securityContext) {
         this.dirScannerConfigProvider = dirScannerConfigProvider;
         this.pathCreator = pathCreator;
         this.zipReceiver = zipReceiver;
         this.receiptIdGenerator = receiptIdGenerator;
+        this.securityContext = securityContext;
 
         this.failureDir = pathCreator.toAppPath(dirScannerConfigProvider.get().getFailureDir());
         FileUtil.ensureDirExists(failureDir);
@@ -138,7 +142,9 @@ public class ZipDirScanner {
         try {
             final AttributeMap attributeMap = createAttributeMap(zipGroup);
 
-            zipReceiver.receive(zipFile, attributeMap);
+            // A file on disk has no authenticated sender, so no user is established for the
+            // receipt check to run as. Run as the processing user, as the datafeed path does.
+            securityContext.asProcessingUser(() -> zipReceiver.receive(zipFile, attributeMap));
             // receive will have cloned our zip, so as there were no problems, we can now delete it
             // and the other files in the group
             deleteZipGroup(zipGroup);

--- a/stroom-proxy/stroom-proxy-app/src/test/java/stroom/proxy/app/handler/TestZipDirScanner.java
+++ b/stroom-proxy/stroom-proxy-app/src/test/java/stroom/proxy/app/handler/TestZipDirScanner.java
@@ -18,6 +18,7 @@ package stroom.proxy.app.handler;
 
 import stroom.meta.api.AttributeMap;
 import stroom.proxy.app.DirScannerConfig;
+import stroom.security.api.CommonSecurityContext;
 import stroom.test.common.DirectorySnapshot;
 import stroom.test.common.DirectorySnapshot.PathSnapshot;
 import stroom.test.common.DirectorySnapshot.Snapshot;
@@ -40,6 +41,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,6 +53,14 @@ class TestZipDirScanner {
 
     @Mock
     private ZipReceiver mockZipReceiver;
+    @Mock
+    private CommonSecurityContext mockSecurityContext;
+
+    /**
+     * Set for the duration of a {@link CommonSecurityContext#asProcessingUser(Runnable)} call
+     * so a test can assert what ran inside it.
+     */
+    private final AtomicBoolean inProcessingUser = new AtomicBoolean(false);
 
     @TempDir
     Path testDir;
@@ -59,6 +69,44 @@ class TestZipDirScanner {
     ArgumentCaptor<Path> zipFileCaptor;
     @Captor
     ArgumentCaptor<AttributeMap> attributeMapCaptor;
+
+    /**
+     * A file arriving on disk has no authenticated sender, so nothing establishes a user for
+     * the receipt check to run as. Receipt-check modes that consult feed status
+     * (FEED_STATUS, RECEIPT_POLICY, FEED_EXISTENCE) then fail with
+     * "No user is currently logged in" and the bundle is quarantined. The datafeed path
+     * already elevates to the processing user before filtering; this path must do the same.
+     */
+    @Test
+    void testScan_receiveRunsAsProcessingUser() {
+        final Path ingestDir = testDir.resolve("ingest");
+        final Path failureDir = testDir.resolve("failure");
+        final DirScannerConfig config = new DirScannerConfig(
+                List.of(ingestDir.toString()),
+                failureDir.toString(),
+                true,
+                StroomDuration.ofSeconds(1));
+
+        final ZipDirScanner zipDirScanner = createZipDirScanner(config);
+
+        final Path zipFile = ingestDir.resolve("file1.zip");
+        TestUtil.createFiles(zipFile);
+
+        final AtomicBoolean receiveSawProcessingUser = new AtomicBoolean(false);
+        Mockito.doAnswer(invocation -> {
+            receiveSawProcessingUser.set(inProcessingUser.get());
+            return null;
+        })
+                .when(mockZipReceiver)
+                .receive(Mockito.any(), Mockito.any());
+
+        zipDirScanner.scan();
+
+        Mockito.verify(mockZipReceiver).receive(Mockito.any(), Mockito.any());
+        assertThat(receiveSawProcessingUser)
+                .withFailMessage("receive() must be invoked as the processing user")
+                .isTrue();
+    }
 
     @Test
     void testScan() {
@@ -298,10 +346,27 @@ class TestZipDirScanner {
         final Path homeDir = testDir.resolve("home");
         final Path stroomTempDir = testDir.resolve("temp");
         final SimplePathCreator pathCreator = new SimplePathCreator(() -> homeDir, () -> stroomTempDir);
+
+        // Run the supplied work, recording that it ran inside the processing user scope.
+        Mockito.lenient()
+                .doAnswer(invocation -> {
+                    final Runnable runnable = invocation.getArgument(0);
+                    inProcessingUser.set(true);
+                    try {
+                        runnable.run();
+                    } finally {
+                        inProcessingUser.set(false);
+                    }
+                    return null;
+                })
+                .when(mockSecurityContext)
+                .asProcessingUser(Mockito.any());
+
         return new ZipDirScanner(
                 () -> config,
                 pathCreator,
                 mockZipReceiver,
-                new ProxyReceiptIdGenerator(() -> "test-node"));
+                new ProxyReceiptIdGenerator(() -> "test-node"),
+                mockSecurityContext);
     }
 }

--- a/unreleased_changes/20260725_231359_763__5671.md
+++ b/unreleased_changes/20260725_231359_763__5671.md
@@ -1,0 +1,27 @@
+* Bug **#5671** : Run directory-scanner file ingest as the processing user so that receipt checks requiring a user succeed.
+
+
+```sh
+# ********************************************************************************
+# Issue number: 5671
+# Issue title:  Directory-scanner file ingest fails any receipt check that requires a user
+# Issue link:   https://github.com/gchq/stroom/issues/5671
+# ********************************************************************************
+
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks.
+
+# --------------------------------------------------------------------------------
+# The following is random text to make this file unique for git's change detection
+# yX2lqncUvzAeifzocEXO4GpAz3Ca8JBQygLbFPCu1sHc4t6tAuyJlD3obCHEBZ3TLHOtOyK3rmcNdYh7
+# Mj1A7p2AhiXM2v662ynsNq6QFinAiGWKNoNokm60az9DpOZDlIRvQFNkHCqRYxeO1ZAJODbn3U8Q5gKc
+# sL3hfeUCCkzWMbT0VPNATvo1MvCTOSr2rBYeA2iHDpf2V0gKL13GcS3cpPMJeAHhki1NOP6sgao9qI0Y
+# pWDE1ONCGRuW63IiBhJpJZMq0TI8hce1rfXNXk50UyXhxjGE9vpvJW1j8aCZduJUqndXAwN6DLGHHIYE
+# 7ZQcYgjpotNKUbmJVp8AoicdgQmBsXrUVayp4dJkR247h9apgFiJti2l8Y91op0A5SHMxLH96H9MyMab
+# pGKxTmEuiM7oxK4W2trOAhoxO814X9sXY4TX2bdxHnDzA7QQ5ZxEspPxQaEwUNWrDg37qQgjdDi8YUwZ
+# rFLHSewGJ0z3jDxAAkbjDJTK7soJTcmjSGtl0AtCrGFPDXmZ6x68HpdeDKQhAmbrq1RXdEYf5J8IWBFQ
+# R1sYC84eP6abZ8OgqRbTzb64HLsTEMssQkBtVGoWAE62CE8QyBXT7DhGhPj1TA3fyeh2ufWBVsIUDc9f
+# --------------------------------------------------------------------------------
+
+```


### PR DESCRIPTION
Fixes #5671.

A file arriving on disk has no authenticated sender, so no user is established for the receipt check to run as. `AttributeMapFilterFactory.doCreate()` already wraps filter **construction** in `asProcessingUserResult(...)`; this wraps the **invocation** on the dir-scanner path, following the precedent and the comment in `ReceiveDataHelper`:

> `// We have authenticated the user to accept the data, but from here on, we run as the`
> `// processing user as the request user won't have perms to do things like check feed status.`

### Change

`ZipDirScanner` takes a `CommonSecurityContext` and runs the receive as the processing user:

```java
securityContext.asProcessingUser(() -> zipReceiver.receive(zipFile, attributeMap));
```

Two production lines plus the injected field. The HTTP datafeed path is untouched.

### This is Option 1 of three — tell me which you want

The issue lists three placements. I have implemented the smallest one so there is something concrete to react to, not because I think the choice is settled.

| | Placement | Trade-off |
|---|---|---|
| **1 (this PR)** | `ZipDirScanner.processZipFile` | Smallest; also runs the data write and forward as the processing user, not only the check |
| 2 | `ZipReceiver.filterAllowedEntries` | Elevates only the check; touches a class used by more than one path |
| 3 | Inside the feed-status service, when no user is present | Fixes every no-user caller at once, but converts a loud failure into a silent elevation for future callers |

Happy to rework this as 2, or drop it if you prefer 3.

### Two things I could not resolve from outside the project

1. **`SimpleReceiver:96,111` has the same `asProcessingUser` wrapping, commented out.** If that was backed out deliberately, this PR may reintroduce whatever the problem was. I did not touch it.
2. `InstantForwardFile:116` and `InstantForwardHttpPost:79` carry the same unelevated `attributeMapFilter.filter(...)` call. Not addressed here — say the word and I will extend this or open a separate PR.

### Testing

`TestZipDirScanner.testScan_receiveRunsAsProcessingUser` asserts that `receive()` is invoked inside the processing-user scope. Written against unmodified `master` first, where it fails with `receive() must be invoked as the processing user`; passes with the change. The three existing tests in that class are unaffected.

`./gradlew clean build` was run from the project root. The only failing test is `stroom-gitrepo` `testAddDirectoryToPath()`, which expects `/tmp/...` and gets `/private/tmp/...` — a macOS symlink artifact that reproduces identically on unmodified `master`, unrelated to this change.

### Not covered

I have reproduced the original defect against `gchq/stroom-proxy:v7.12.6` end to end, but I have not run a live proxy with this build to confirm the fix in situ — the evidence here is the unit test plus the code path. If you would like a live confirmation before merging, I can do that.
