### PR TITLE
#5692 Fix `getState()` reporting "No state doc can be found for name:…

### DIFF
--- a/stroom-state/stroom-state-impl/src/main/java/stroom/state/impl/MockStateModule.java
+++ b/stroom-state/stroom-state-impl/src/main/java/stroom/state/impl/MockStateModule.java
@@ -22,11 +22,9 @@ import stroom.explorer.api.ExplorerActionHandler;
 import stroom.importexport.api.ImportExportActionHandler;
 import stroom.pipeline.xsltfunctions.StateLookup;
 import stroom.query.language.functions.StateFetcher;
-import stroom.query.language.functions.StateProvider;
 import stroom.state.impl.pipeline.StateElementModule;
 import stroom.state.impl.pipeline.StateFetcherImpl;
 import stroom.state.impl.pipeline.StateLookupImpl;
-import stroom.state.impl.pipeline.StateProviderImpl;
 import stroom.state.shared.ScyllaDbDoc;
 import stroom.util.entityevent.EntityEvent;
 import stroom.util.guice.GuiceUtil;
@@ -42,7 +40,7 @@ public class MockStateModule extends AbstractModule {
         install(new StateElementModule());
 
         bind(StateLookup.class).to(StateLookupImpl.class);
-        GuiceUtil.buildMultiBinder(binder(), StateProvider.class).addBinding(StateProviderImpl.class);
+        // No Scylla backed StateProvider, to match StateModule. See gh-5692.
         bind(StateFetcher.class).to(StateFetcherImpl.class);
 
 //        // Services

--- a/stroom-state/stroom-state-impl/src/main/java/stroom/state/impl/StateModule.java
+++ b/stroom-state/stroom-state-impl/src/main/java/stroom/state/impl/StateModule.java
@@ -27,11 +27,9 @@ import stroom.query.api.datasource.DataSourceProvider;
 import stroom.query.common.v2.IndexFieldProvider;
 import stroom.query.common.v2.SearchProvider;
 import stroom.query.language.functions.StateFetcher;
-import stroom.query.language.functions.StateProvider;
 import stroom.state.impl.pipeline.StateElementModule;
 import stroom.state.impl.pipeline.StateFetcherImpl;
 import stroom.state.impl.pipeline.StateLookupImpl;
-import stroom.state.impl.pipeline.StateProviderImpl;
 import stroom.state.shared.ScyllaDbDoc;
 import stroom.state.shared.StateDoc;
 import stroom.util.RunnableWrapper;
@@ -51,7 +49,9 @@ public class StateModule extends AbstractModule {
         install(new StateElementModule());
 
         bind(StateLookup.class).to(StateLookupImpl.class);
-        GuiceUtil.buildMultiBinder(binder(), StateProvider.class).addBinding(StateProviderImpl.class);
+        // The Scylla backed StateProvider is deliberately not bound. StateFetcherImpl stops at the first
+        // provider that returns a non null value and a ValErr counts as a value, so a Scylla provider that
+        // can't find a StateDoc for the map name masks the Plan B provider that can. See gh-5692.
         bind(StateFetcher.class).to(StateFetcherImpl.class);
 
         // Caches

--- a/unreleased_changes/20260804_111440_000__5692.md
+++ b/unreleased_changes/20260804_111440_000__5692.md
@@ -1,0 +1,10 @@
+* Bug **#5692** : Fix `getState()` reporting "No state doc can be found for name: ..." for a Plan B store. The Scylla backed state provider is no longer registered, so it can no longer mask the Plan B provider.
+
+```sh
+# ********************************************************************************
+# Issue number: 5692
+# Issue title:  PlanB No state doc found
+# Issue tags:   f:planb
+# Issue link:   https://github.com/gchq/stroom/issues/5692
+# ********************************************************************************
+```


### PR DESCRIPTION
… ..." for a Plan B store