### PR TITLE
gh-5713 Space delimit bitmap-lookup values

### DIFF
--- a/stroom-pipeline/src/main/java/stroom/pipeline/refdata/store/offheapstore/StringByteBufferConsumer.java
+++ b/stroom-pipeline/src/main/java/stroom/pipeline/refdata/store/offheapstore/StringByteBufferConsumer.java
@@ -51,8 +51,8 @@ public class StringByteBufferConsumer implements RefDataValueByteBufferConsumer 
                 str, ByteBufferUtils.byteBufferInfo(byteBuffer)));
 
         try {
-            // Not sure why we use WHOLE_TEXT_NODE as we are potentially calling characters() multiple times for a
-            // bitmap lookup. Maybe that is what is adding the space between bitmaplookup values.
+            // For a bitmap lookup characters() is called once per matched bit position; the
+            // space delimiting of those values is done by the receiver.
             receiver.characters(str, RefDataValueProxyConsumer.NULL_LOCATION, ReceiverOptions.WHOLE_TEXT_NODE);
         } catch (final XPathException e) {
             throw new RuntimeException(LogUtil.message("Error passing string {} to receiver", str), e);

--- a/stroom-pipeline/src/main/java/stroom/pipeline/xsltfunctions/AbstractLookup.java
+++ b/stroom-pipeline/src/main/java/stroom/pipeline/xsltfunctions/AbstractLookup.java
@@ -92,6 +92,16 @@ abstract class AbstractLookup extends StroomExtensionFunctionCall {
         return sequenceMakerFactory.create(context);
     }
 
+    /**
+     * Override to read any arguments beyond the common five (map, key, time,
+     * ignoreWarnings, trace). Called on every function call before {@code doLookup()}.
+     */
+    protected void parseAdditionalArguments(final String functionName,
+                                            final XPathContext context,
+                                            final Sequence[] arguments) throws XPathException {
+        // Default is no additional arguments.
+    }
+
     @Override
     protected Sequence call(final String functionName, final XPathContext context, final Sequence[] arguments) {
         LOGGER.trace("call({}, {}, {}", functionName, context, arguments);
@@ -127,6 +137,9 @@ abstract class AbstractLookup extends StroomExtensionFunctionCall {
             // Find out if we are going to trace the lookup.
             final boolean traceLookup = arguments.length > 4
                                         && NullSafe.isTrue(getSafeBoolean(functionName, context, arguments, 4));
+
+            // Let subclasses read any arguments beyond the common five.
+            parseAdditionalArguments(functionName, context, arguments);
 
             // Make sure we can get the date ok.
             long ms = defaultMs;
@@ -525,6 +538,8 @@ abstract class AbstractLookup extends StroomExtensionFunctionCall {
 
     static class SequenceMaker {
 
+        static final String DEFAULT_DELIMITER = " ";
+
         private final XPathContext context;
         private final RefDataValueProxyConsumerFactory.Factory consumerFactoryFactory;
         private Builder builder;
@@ -538,9 +553,18 @@ abstract class AbstractLookup extends StroomExtensionFunctionCall {
         }
 
         void open() throws XPathException {
+            open(DEFAULT_DELIMITER);
+        }
+
+        /**
+         * @param delimiter The delimiter to place between each consumed value, e.g.
+         *                  between the values of the matched bit positions in a
+         *                  bitmap lookup. An empty delimiter concatenates the values.
+         */
+        void open(final String delimiter) throws XPathException {
             LOGGER.trace("open()");
             // Make sure we have made a consumer.
-            ensureConsumer();
+            ensureConsumer(delimiter);
             consumer.startDocument();
         }
 
@@ -557,7 +581,7 @@ abstract class AbstractLookup extends StroomExtensionFunctionCall {
             return consumer.consume(refDataValueProxy);
         }
 
-        private void ensureConsumer() {
+        private void ensureConsumer(final String delimiter) {
             LOGGER.trace("ensureConsumer()");
             if (consumer == null) {
                 LOGGER.trace("ensureConsumer() - Creating consumer");
@@ -569,9 +593,9 @@ abstract class AbstractLookup extends StroomExtensionFunctionCall {
                 builder = new TinyBuilder(pipelineConfiguration);
 
                 // Wrap the builder so that when multiple values are consumed into the one
-                // document (e.g. by stroom:bitmap-lookup()) they are space delimited, rather
+                // document (e.g. by stroom:bitmap-lookup()) they are delimited, rather
                 // than being concatenated with nothing between them.
-                valueDelimitingReceiver = new ValueDelimitingReceiver(builder);
+                valueDelimitingReceiver = new ValueDelimitingReceiver(builder, delimiter);
 
                 // At this point we don't know if we are dealing with heap object values or off-heap bytebuffer values.
                 // We also don't know if the value is a string or a fastinfoset.
@@ -602,8 +626,8 @@ abstract class AbstractLookup extends StroomExtensionFunctionCall {
 
 
     /**
-     * Delimits each logical value written to the wrapped {@link Receiver} with a single
-     * space, e.g. the values of each matched bit position in a bitmap lookup.
+     * Delimits each logical value written to the wrapped {@link Receiver}, e.g. the
+     * values of each matched bit position in a bitmap lookup.
      * <p>
      * {@link #markNewValue()} marks the boundary between one logical value and the next.
      * The delimiter is not written until the new value produces some output, so a value
@@ -613,13 +637,14 @@ abstract class AbstractLookup extends StroomExtensionFunctionCall {
      */
     static class ValueDelimitingReceiver extends ProxyReceiver {
 
-        private static final String DELIMITER = " ";
+        private final String delimiter;
 
         private boolean hasContent = false;
         private boolean isDelimiterPending = false;
 
-        ValueDelimitingReceiver(final Receiver nextReceiver) {
+        ValueDelimitingReceiver(final Receiver nextReceiver, final String delimiter) {
             super(nextReceiver);
+            this.delimiter = delimiter;
         }
 
         /**
@@ -634,7 +659,10 @@ abstract class AbstractLookup extends StroomExtensionFunctionCall {
         private void writeDelimiterIfPending() throws XPathException {
             if (isDelimiterPending) {
                 isDelimiterPending = false;
-                nextReceiver.characters(DELIMITER, ExplicitLocation.UNKNOWN_LOCATION, ReceiverOptions.WHOLE_TEXT_NODE);
+                if (!delimiter.isEmpty()) {
+                    nextReceiver.characters(
+                            delimiter, ExplicitLocation.UNKNOWN_LOCATION, ReceiverOptions.WHOLE_TEXT_NODE);
+                }
             }
         }
 

--- a/stroom-pipeline/src/main/java/stroom/pipeline/xsltfunctions/AbstractLookup.java
+++ b/stroom-pipeline/src/main/java/stroom/pipeline/xsltfunctions/AbstractLookup.java
@@ -46,11 +46,18 @@ import jakarta.inject.Inject;
 import net.sf.saxon.Configuration;
 import net.sf.saxon.event.Builder;
 import net.sf.saxon.event.PipelineConfiguration;
+import net.sf.saxon.event.ProxyReceiver;
+import net.sf.saxon.event.Receiver;
+import net.sf.saxon.event.ReceiverOptions;
 import net.sf.saxon.expr.XPathContext;
+import net.sf.saxon.expr.parser.ExplicitLocation;
+import net.sf.saxon.expr.parser.Location;
 import net.sf.saxon.om.EmptyAtomicSequence;
+import net.sf.saxon.om.NodeName;
 import net.sf.saxon.om.Sequence;
 import net.sf.saxon.trans.XPathException;
 import net.sf.saxon.tree.tiny.TinyBuilder;
+import net.sf.saxon.type.SchemaType;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -521,6 +528,7 @@ abstract class AbstractLookup extends StroomExtensionFunctionCall {
         private final XPathContext context;
         private final RefDataValueProxyConsumerFactory.Factory consumerFactoryFactory;
         private Builder builder;
+        private ValueDelimitingReceiver valueDelimitingReceiver;
         private GenericRefDataValueProxyConsumer consumer;
 
         SequenceMaker(final XPathContext context,
@@ -542,6 +550,10 @@ abstract class AbstractLookup extends StroomExtensionFunctionCall {
         }
 
         boolean consume(final RefDataValueProxy refDataValueProxy) throws XPathException {
+            // Delimit this value from any previously consumed value, e.g. for a bitmap lookup.
+            // The delimiter is only written if this consume() call actually produces output,
+            // so a failed lookup cannot result in doubled or trailing delimiters.
+            valueDelimitingReceiver.markNewValue();
             return consumer.consume(refDataValueProxy);
         }
 
@@ -556,12 +568,17 @@ abstract class AbstractLookup extends StroomExtensionFunctionCall {
 
                 builder = new TinyBuilder(pipelineConfiguration);
 
+                // Wrap the builder so that when multiple values are consumed into the one
+                // document (e.g. by stroom:bitmap-lookup()) they are space delimited, rather
+                // than being concatenated with nothing between them.
+                valueDelimitingReceiver = new ValueDelimitingReceiver(builder);
+
                 // At this point we don't know if we are dealing with heap object values or off-heap bytebuffer values.
                 // We also don't know if the value is a string or a fastinfoset.
                 consumer = new GenericRefDataValueProxyConsumer(
-                        builder,
+                        valueDelimitingReceiver,
                         pipelineConfiguration,
-                        consumerFactoryFactory.create(builder, pipelineConfiguration));
+                        consumerFactoryFactory.create(valueDelimitingReceiver, pipelineConfiguration));
             }
         }
 
@@ -577,6 +594,67 @@ abstract class AbstractLookup extends StroomExtensionFunctionCall {
             builder.reset();
 
             return sequence;
+        }
+    }
+
+
+// --------------------------------------------------------------------------------
+
+
+    /**
+     * Delimits each logical value written to the wrapped {@link Receiver} with a single
+     * space, e.g. the values of each matched bit position in a bitmap lookup.
+     * <p>
+     * {@link #markNewValue()} marks the boundary between one logical value and the next.
+     * The delimiter is not written until the new value produces some output, so a value
+     * that produces no output (e.g. a failed lookup for one bit position) will not
+     * result in doubled or trailing delimiters.
+     * </p>
+     */
+    static class ValueDelimitingReceiver extends ProxyReceiver {
+
+        private static final String DELIMITER = " ";
+
+        private boolean hasContent = false;
+        private boolean isDelimiterPending = false;
+
+        ValueDelimitingReceiver(final Receiver nextReceiver) {
+            super(nextReceiver);
+        }
+
+        /**
+         * Mark the start of a new logical value. If a previously consumed value has
+         * written content to the receiver then a delimiter will be written before any
+         * content of the new value.
+         */
+        void markNewValue() {
+            isDelimiterPending = hasContent;
+        }
+
+        private void writeDelimiterIfPending() throws XPathException {
+            if (isDelimiterPending) {
+                isDelimiterPending = false;
+                nextReceiver.characters(DELIMITER, ExplicitLocation.UNKNOWN_LOCATION, ReceiverOptions.WHOLE_TEXT_NODE);
+            }
+        }
+
+        @Override
+        public void characters(final CharSequence chars,
+                               final Location locationId,
+                               final int properties) throws XPathException {
+            writeDelimiterIfPending();
+            hasContent = true;
+            super.characters(chars, locationId, properties);
+        }
+
+        @Override
+        public void startElement(final NodeName elemName,
+                                 final SchemaType typeCode,
+                                 final Location location,
+                                 final int properties) throws XPathException {
+            writeDelimiterIfPending();
+            hasContent = true;
+            super.startElement(elemName, typeCode, location, properties);
         }
     }
 }

--- a/stroom-pipeline/src/main/java/stroom/pipeline/xsltfunctions/BitmapLookup.java
+++ b/stroom-pipeline/src/main/java/stroom/pipeline/xsltfunctions/BitmapLookup.java
@@ -150,11 +150,9 @@ class BitmapLookup extends AbstractLookup {
             if (result.getRefDataValueProxy().isPresent()) {
                 final SequenceMaker sequenceMaker = getOrCreateSequenceMaker(sequenceMakerRef, xPathContext);
 
-                // When multiple values are consumed they appear to be separated with a ' '.
-                // Not really sure why as it is not something we are doing explicitly.  May be something to
-                // do with how we call characters() on the TinyBuilder deeper down.
-                // receiver.characters(
-                // str, RefDataValueProxyConsumer.NULL_LOCATION, ReceiverOptions.WHOLE_TEXT_NODE);
+                // When multiple values are consumed the SequenceMaker delimits each one with
+                // a ' ', so the result is a space delimited list of the values for all matched
+                // bit positions.
 
                 final RefDataValueProxy refDataValueProxy = result.getRefDataValueProxy().get();
 

--- a/stroom-pipeline/src/main/java/stroom/pipeline/xsltfunctions/BitmapLookup.java
+++ b/stroom-pipeline/src/main/java/stroom/pipeline/xsltfunctions/BitmapLookup.java
@@ -47,6 +47,8 @@ class BitmapLookup extends AbstractLookup {
 
     public static final String FUNCTION_NAME = "bitmap-lookup";
 
+    private String delimiter = SequenceMaker.DEFAULT_DELIMITER;
+
     @Inject
     BitmapLookup(final ReferenceData referenceData,
                  final MetaHolder metaHolder,
@@ -55,13 +57,28 @@ class BitmapLookup extends AbstractLookup {
         super(referenceData, metaHolder, sequenceMakerFactory, taskContextFactory);
     }
 
+    @Override
+    protected void parseAdditionalArguments(final String functionName,
+                                            final XPathContext context,
+                                            final Sequence[] arguments) throws XPathException {
+        // The optional sixth argument sets the delimiter placed between the values of
+        // the matched bit positions. Defaults to a single space.
+        if (arguments.length > 5) {
+            delimiter = Objects.requireNonNullElse(
+                    getSafeString(functionName, context, arguments, 5),
+                    SequenceMaker.DEFAULT_DELIMITER);
+        } else {
+            delimiter = SequenceMaker.DEFAULT_DELIMITER;
+        }
+    }
+
     private SequenceMaker getOrCreateSequenceMaker(final AtomicReference<SequenceMaker> sequenceMakerRef,
                                                    final XPathContext xPathContext) throws XPathException {
         Objects.requireNonNull(sequenceMakerRef);
         Objects.requireNonNull(xPathContext);
         if (sequenceMakerRef.get() == null) {
             final SequenceMaker sequenceMaker = createSequenceMaker(xPathContext);
-            sequenceMaker.open();
+            sequenceMaker.open(delimiter);
             sequenceMakerRef.set(sequenceMaker);
         }
         return sequenceMakerRef.get();
@@ -150,9 +167,9 @@ class BitmapLookup extends AbstractLookup {
             if (result.getRefDataValueProxy().isPresent()) {
                 final SequenceMaker sequenceMaker = getOrCreateSequenceMaker(sequenceMakerRef, xPathContext);
 
-                // When multiple values are consumed the SequenceMaker delimits each one with
-                // a ' ', so the result is a space delimited list of the values for all matched
-                // bit positions.
+                // When multiple values are consumed the SequenceMaker delimits each one (with
+                // a ' ' unless the optional delimiter argument was supplied), so the result is
+                // a delimited list of the values for all matched bit positions.
 
                 final RefDataValueProxy refDataValueProxy = result.getRefDataValueProxy().get();
 

--- a/stroom-pipeline/src/main/java/stroom/pipeline/xsltfunctions/DataStoreXsltFunctionModule.java
+++ b/stroom-pipeline/src/main/java/stroom/pipeline/xsltfunctions/DataStoreXsltFunctionModule.java
@@ -40,13 +40,14 @@ public class DataStoreXsltFunctionModule extends AbstractXsltFunctionModule {
             super(
                     BitmapLookup.FUNCTION_NAME,
                     2,
-                    5,
+                    6,
                     new SequenceType[]{
                             SequenceType.SINGLE_STRING,
                             SequenceType.SINGLE_STRING,
                             SequenceType.OPTIONAL_STRING,
                             SequenceType.OPTIONAL_BOOLEAN,
-                            SequenceType.OPTIONAL_BOOLEAN},
+                            SequenceType.OPTIONAL_BOOLEAN,
+                            SequenceType.OPTIONAL_STRING},
                     SequenceType.NODE_SEQUENCE,
                     functionCallProvider);
         }

--- a/stroom-pipeline/src/test/java/stroom/pipeline/xsltfunctions/TestBitmapLookup.java
+++ b/stroom-pipeline/src/test/java/stroom/pipeline/xsltfunctions/TestBitmapLookup.java
@@ -21,8 +21,14 @@ import stroom.feed.shared.FeedDoc;
 import stroom.pipeline.refdata.LookupIdentifier;
 import stroom.pipeline.refdata.ReferenceData;
 import stroom.pipeline.refdata.ReferenceDataResult;
+import stroom.pipeline.refdata.store.RefDataStore;
 import stroom.pipeline.refdata.store.RefDataValueProxy;
+import stroom.pipeline.refdata.store.RefDataValueProxyConsumerFactory;
 import stroom.pipeline.refdata.store.RefStreamDefinition;
+import stroom.pipeline.refdata.store.StringValue;
+import stroom.pipeline.refdata.store.ValueConsumerId;
+import stroom.pipeline.refdata.store.onheapstore.OnHeapRefDataValueProxyConsumer;
+import stroom.pipeline.refdata.store.onheapstore.StringValueConsumer;
 import stroom.pipeline.shared.PipelineDoc;
 import stroom.pipeline.shared.data.PipelineReference;
 import stroom.pipeline.state.MetaHolder;
@@ -35,6 +41,9 @@ import stroom.util.logging.LambdaLoggerFactory;
 import stroom.util.logging.LogUtil;
 import stroom.util.shared.Severity;
 
+import net.sf.saxon.Configuration;
+import net.sf.saxon.om.NodeInfo;
+import net.sf.saxon.om.Sequence;
 import net.sf.saxon.trans.XPathException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,6 +59,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -364,6 +374,167 @@ class TestBitmapLookup extends AbstractXsltFunctionTest<BitmapLookup> {
                 Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
 
 //        assertLoggedTopLevelSeverity(Severity.INFO, "success");
+    }
+
+    @Test
+    void doLookup_multipleValues_spaceDelimited() throws Exception {
+        // Key of "74" is 1001010 in binary so bit positions 1, 3 and 6 are set.
+        // The docs state that the values for all matched bit positions are returned
+        // as a space delimited list, e.g. "Manage_Users View_Data Manage_Volumes".
+        final Sequence sequence = doLookupWithRealSequenceMaker(
+                "74",
+                Map.of(
+                        "1", "Manage_Users",
+                        "3", "View_Data",
+                        "6", "Manage_Volumes"));
+
+        Assertions.assertThat(sequence)
+                .isInstanceOf(NodeInfo.class);
+        Assertions.assertThat(((NodeInfo) sequence).getStringValue())
+                .isEqualTo("Manage_Users View_Data Manage_Volumes");
+    }
+
+    @Test
+    void doLookup_multipleValues_unmatchedBit_spaceDelimited() throws Exception {
+        // Bit positions 1, 3 and 6 are set but position 3 has no entry in the map,
+        // so no delimiter should be added for it, i.e. no double/trailing spaces.
+        final Sequence sequence = doLookupWithRealSequenceMaker(
+                "74",
+                Map.of(
+                        "1", "Manage_Users",
+                        "6", "Manage_Volumes"));
+
+        Assertions.assertThat(sequence)
+                .isInstanceOf(NodeInfo.class);
+        Assertions.assertThat(((NodeInfo) sequence).getStringValue())
+                .isEqualTo("Manage_Users Manage_Volumes");
+    }
+
+    @Test
+    void doLookup_multipleValues_unmatchedLastBit_noTrailingDelimiter() throws Exception {
+        // Bit positions 1, 3 and 6 are set but position 6 has no entry in the map,
+        // so there should be no trailing delimiter.
+        final Sequence sequence = doLookupWithRealSequenceMaker(
+                "74",
+                Map.of(
+                        "1", "Manage_Users",
+                        "3", "View_Data"));
+
+        Assertions.assertThat(sequence)
+                .isInstanceOf(NodeInfo.class);
+        Assertions.assertThat(((NodeInfo) sequence).getStringValue())
+                .isEqualTo("Manage_Users View_Data");
+    }
+
+    @Test
+    void doLookup_singleValue_noDelimiter() throws Exception {
+        // Key of "2" is 10 in binary so only bit position 1 is set.
+        final Sequence sequence = doLookupWithRealSequenceMaker(
+                "2",
+                Map.of("1", "Manage_Users"));
+
+        Assertions.assertThat(sequence)
+                .isInstanceOf(NodeInfo.class);
+        Assertions.assertThat(((NodeInfo) sequence).getStringValue())
+                .isEqualTo("Manage_Users");
+    }
+
+    /**
+     * Run a lookup through a real {@link SequenceMaker} (i.e. a real Saxon
+     * {@link net.sf.saxon.tree.tiny.TinyBuilder} fed by the real on-heap value consumers)
+     * so the test sees the sequence exactly as the XSLT would.
+     *
+     * @param key            The bitmap lookup key.
+     * @param bitPosToValue  Map of bit position (as a string key) to the reference data
+     *                       value for that bit position. Bit positions absent from the
+     *                       map behave as a failed lookup for that key.
+     */
+    private Sequence doLookupWithRealSequenceMaker(final String key,
+                                                   final Map<String, String> bitPosToValue) {
+        pipelineReferences = List.of(
+                new PipelineReference(
+                        PipelineDoc.buildDocRef().randomUuid().name("MyPipe").build(),
+                        FeedDoc.buildDocRef().randomUuid().name("MY_FEED").build(),
+                        StreamTypeNames.REFERENCE));
+
+        final RefStreamDefinition refStreamDefinition = new RefStreamDefinition(
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                123L);
+
+        initRealSequenceMaker();
+
+        Mockito.doAnswer(
+                        invocation -> {
+                            final LookupIdentifier lookupIdentifier = invocation.getArgument(1);
+                            final ReferenceDataResult result = invocation.getArgument(2);
+
+                            // Add one effective stream
+                            result.addEffectiveStream(pipelineReferences.get(0), refStreamDefinition);
+
+                            final ReferenceDataResult resultSpy = Mockito.spy(result);
+                            final String value = bitPosToValue.get(lookupIdentifier.getKey());
+                            final RefDataValueProxy refDataValueProxy = createStringValueProxy(value);
+
+                            Mockito.doReturn(Optional.of(refDataValueProxy))
+                                    .when(resultSpy).getRefDataValueProxy();
+
+                            return resultSpy;
+                        }).when(mockReferenceData)
+                .ensureReferenceDataAvailability(Mockito.any(), Mockito.any(), Mockito.any());
+
+        return callFunctionWithSimpleArgs(MAP, key, Instant.now(), false, false);
+    }
+
+    /**
+     * @param value The value the proxy will supply, or null to simulate the key
+     *              not being found in the map.
+     */
+    private RefDataValueProxy createStringValueProxy(final String value) {
+        final RefDataValueProxy refDataValueProxy = Mockito.mock(RefDataValueProxy.class);
+        if (value == null) {
+            // Key not found so nothing is consumed
+            Mockito.when(refDataValueProxy.consumeValue(Mockito.any()))
+                    .thenReturn(false);
+        } else {
+            // Emulate what SingleRefDataValueProxy does for an on-heap store, i.e.
+            // delegate to the real on-heap consumer chain.
+            Mockito.when(refDataValueProxy.supplyValue())
+                    .thenReturn(Optional.of(StringValue.of(value)));
+            Mockito.when(refDataValueProxy.consumeValue(Mockito.any()))
+                    .thenAnswer(invocation -> {
+                        final RefDataValueProxyConsumerFactory consumerFactory =
+                                invocation.getArgument(0);
+                        return consumerFactory.getConsumer(RefDataStore.StorageType.ON_HEAP)
+                                .consume(refDataValueProxy);
+                    });
+        }
+        return refDataValueProxy;
+    }
+
+    private void initRealSequenceMaker() {
+        final Configuration configuration = new Configuration();
+        Mockito.when(getMockXPathContext().getConfiguration())
+                .thenReturn(configuration);
+
+        final OnHeapRefDataValueProxyConsumer.Factory onHeapConsumerFactory =
+                (receiver, pipelineConfiguration) -> new OnHeapRefDataValueProxyConsumer(
+                        receiver,
+                        pipelineConfiguration,
+                        Map.of(
+                                new ValueConsumerId(StringValue.TYPE_ID),
+                                new StringValueConsumer.Factory()));
+
+        final RefDataValueProxyConsumerFactory.Factory consumerFactoryFactory =
+                (receiver, pipelineConfiguration) -> new RefDataValueProxyConsumerFactory(
+                        receiver,
+                        pipelineConfiguration,
+                        onHeapConsumerFactory,
+                        (receiver2, pipelineConfiguration2) -> null);
+
+        Mockito.when(mockSequenceMakerFactory.create(Mockito.any()))
+                .thenAnswer(invocation ->
+                        new SequenceMaker(invocation.getArgument(0), consumerFactoryFactory));
     }
 
     private void assertLoggedTopLevelSeverity(final Severity expectedTopLevelSeverity) {

--- a/stroom-pipeline/src/test/java/stroom/pipeline/xsltfunctions/TestBitmapLookup.java
+++ b/stroom-pipeline/src/test/java/stroom/pipeline/xsltfunctions/TestBitmapLookup.java
@@ -439,6 +439,57 @@ class TestBitmapLookup extends AbstractXsltFunctionTest<BitmapLookup> {
                 .isEqualTo("Manage_Users");
     }
 
+    @Test
+    void doLookup_multipleValues_customDelimiter() throws Exception {
+        // The optional 6th argument sets the delimiter used between the values.
+        final Sequence sequence = doLookupWithRealSequenceMaker(
+                "74",
+                Map.of(
+                        "1", "Manage_Users",
+                        "3", "View_Data",
+                        "6", "Manage_Volumes"),
+                ",");
+
+        Assertions.assertThat(sequence)
+                .isInstanceOf(NodeInfo.class);
+        Assertions.assertThat(((NodeInfo) sequence).getStringValue())
+                .isEqualTo("Manage_Users,View_Data,Manage_Volumes");
+    }
+
+    @Test
+    void doLookup_multipleValues_emptyDelimiter() throws Exception {
+        // An explicit empty delimiter concatenates the values with nothing between
+        // them, i.e. the behaviour before space delimiting was fixed.
+        final Sequence sequence = doLookupWithRealSequenceMaker(
+                "74",
+                Map.of(
+                        "1", "Manage_Users",
+                        "3", "View_Data",
+                        "6", "Manage_Volumes"),
+                "");
+
+        Assertions.assertThat(sequence)
+                .isInstanceOf(NodeInfo.class);
+        Assertions.assertThat(((NodeInfo) sequence).getStringValue())
+                .isEqualTo("Manage_UsersView_DataManage_Volumes");
+    }
+
+    @Test
+    void doLookup_multipleValues_multiCharDelimiter() throws Exception {
+        final Sequence sequence = doLookupWithRealSequenceMaker(
+                "74",
+                Map.of(
+                        "1", "Manage_Users",
+                        "3", "View_Data",
+                        "6", "Manage_Volumes"),
+                " | ");
+
+        Assertions.assertThat(sequence)
+                .isInstanceOf(NodeInfo.class);
+        Assertions.assertThat(((NodeInfo) sequence).getStringValue())
+                .isEqualTo("Manage_Users | View_Data | Manage_Volumes");
+    }
+
     /**
      * Run a lookup through a real {@link SequenceMaker} (i.e. a real Saxon
      * {@link net.sf.saxon.tree.tiny.TinyBuilder} fed by the real on-heap value consumers)
@@ -448,9 +499,12 @@ class TestBitmapLookup extends AbstractXsltFunctionTest<BitmapLookup> {
      * @param bitPosToValue  Map of bit position (as a string key) to the reference data
      *                       value for that bit position. Bit positions absent from the
      *                       map behave as a failed lookup for that key.
+     * @param extraArgs      Any arguments to pass after the standard five, e.g. the
+     *                       optional delimiter.
      */
     private Sequence doLookupWithRealSequenceMaker(final String key,
-                                                   final Map<String, String> bitPosToValue) {
+                                                   final Map<String, String> bitPosToValue,
+                                                   final Object... extraArgs) {
         pipelineReferences = List.of(
                 new PipelineReference(
                         PipelineDoc.buildDocRef().randomUuid().name("MyPipe").build(),
@@ -483,7 +537,10 @@ class TestBitmapLookup extends AbstractXsltFunctionTest<BitmapLookup> {
                         }).when(mockReferenceData)
                 .ensureReferenceDataAvailability(Mockito.any(), Mockito.any(), Mockito.any());
 
-        return callFunctionWithSimpleArgs(MAP, key, Instant.now(), false, false);
+        final List<Object> args = new ArrayList<>(
+                List.of(MAP, key, Instant.now(), false, false));
+        args.addAll(List.of(extraArgs));
+        return callFunctionWithSimpleArgs(args.toArray());
     }
 
     /**

--- a/unreleased_changes/20260812_183846_523__5713.md
+++ b/unreleased_changes/20260812_183846_523__5713.md
@@ -1,0 +1,67 @@
+* Bug **#5713** : Fix `bitmap-lookup` returning the values of the matched bit positions concatenated with no delimiter. The values are now space delimited as documented.
+
+
+```sh
+# ********************************************************************************
+# Issue number: 5713
+# Issue title:  bitmap-lookup returns matched values concatenated with no delimiter, docs say space delimited
+# Issue link:   https://github.com/gchq/stroom/issues/5713
+# ********************************************************************************
+
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Bug **#123** : Fix bug with an associated GitHub issue in this repository.
+#
+# * Bug **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository.
+#
+# * Feature **#789** : Add new feature X.
+#
+# * Bug : Fix bug with no associated GitHub issue.
+#
+#
+# Note: The line must start '* XXX ', where 'XXX' is a valid category,
+#       one of [Bug Feature Refactor Dependency Build].
+
+
+# --------------------------------------------------------------------------------
+# The following is random text to make this file unique for git's change detection
+# XFcHGlM9OpiwCzPxwXi39vM8uXn2tBx4cYKOx0wlIzLE8GN10E8jQPolvz1z0FaglLZs34doxwY7oHUR
+# bIJ1LruLxwmZWjrBBM7Y1P7NlCrrukK7WOznbcSsTDQtUr81hVhA0ZlexSdxpKcyaxvu7RQYX0t31ptZ
+# 1w4kKlBlwATjhWEQLGAJqWJg5IfvUO6zB1Kqs1uXcBT6JS0P0TncBQwPIX506P0ngHhBe0lUxVTdI2RX
+# SfKSeHG5wfVEW22ulB0NBQuRT2sCqFJPvYmVdiunOXk3yeBZ5fqklVsDjo8lJEY7JeSjd4uB3AGnVQSk
+# zCtFrrccGLBUCwFmKE4VmmEydsnavye598tanmkAvE5wzitVfpd3t2CqyW7oMqflfKfWpIbAk3JdEw50
+# qDAq6wJBzVO4CWKX4U1uQ740QBjljt0aztGo1MJEUAJ9C0GV9A4bKi0RkGdqEyfIt6FLtPsWbkLRgJZ7
+# fL55MhltJH0oa9z0eOXtp1DSqw5g3kjzDP0UsoNSCnXKilkRt2V9fEdnnNXEh7F3cUDcOLnG0L3kPPd5
+# qQJ4iiIWiLYlhSr1ddR3q6VZEVGzKnOwI560hgbewO3idNfV2sMotBhy8dvWoGI4hmCf9qH3DKcZi8S6
+# iV9EpW2Xlgq5WMsdhM2Tsx7GLWRopZNkQcjN8ZvZyJMux2VfW3ecN5MeWoXFKgJMPBdw0AxX7kpyNK93
+# r7dYODjtQdctMLQztsjuBBbmylUx4rDbp30HjdB5Z6GUE9nwd9MAnwbbxQm3r31PzVVJdiyFQa26x1Cj
+# 9FYXfSMyjEihpKkYkEQiK9YgBgGEThCbVGA5Mx6vAJNoMwRdAq7q879DfoAcGWTVY4Kx9S0AAfEkwW5x
+# UWznCqBN6rynqH8qggXxCzpdBSOyxWbhJdCnB5aglneSk5GzkHfq7dJovuaXWMJMSDHrRjJIUUF60aqq
+# 7pyTfonGS6RgVVq4T7DpCUBvfePuJuJDhV6WLTJFzn2hOc5qINvH9Fpkn2cjIvd5p8CaYGz2JXPXGtqK
+# ahJhYqFGEjENTk62QhqjeU8dqeNehBLU7IGPC3joFS9GupP6FDkaRXXhJQpjMiu0dkIWt6rEHzfpFObs
+# 5aGsZt7dd06vr8vSoYJmnOwOBbeiIjNGid6iIpQl8Ho7xXWWuDmwQCDWqvVPCm0RPQmq0LOJjYOgWdbX
+# sRKMNjo59lqKS0VbEiEci338lrBwU0vFUtsrJqRmq5bpMMcax8xc8KYMQbnVQcfWjRoYVHboemt8urwd
+# cJ3hmfomDafeBktTXiNfkKywuLy1T5P8omjLETJ1d5RuwAtZI2REcuzeREnFOFVh17tBOMzy1aTdR1Bc
+# kPPkXGUnvybtau0z4xmrtLzI0iNR3klncnGXrzU11ljmx9JjFhDS3tEQs4DWWpZzHcWLR9JEyRBRSeTD
+# uOh6Mms5fKy5d9YjFcJdSc4z5WbyDLUIcNHJ3ERYhepFUk8vB9sp0i8roddXsBAYCl85EwLCIX83oodq
+# 09EiKYzgFYx5ZGKE900fHYMputLsJeqz61QTsbEDOtEtpjOskhnZ5vgJcUlFNEoFbvqUWijueNxRldq0
+# p948TsIyYnpxVITOa6jFy7NMzXh9SOczGGo4pYdNZokEQoKosWejSIlkwxErsxcFQbc5WHnDXwbI6rK2
+# F6dTLWDu4ixKCFHc4TXP8DkVEBec2u9xQa9SIr4xf91ijWZCPW01MV3URvz1eareXzYJn4pjQJJSWTx4
+# 0KBa0IbcGsj8En8LIPtz3Vd93zHSUHiqR8csXpLRFXLoO6ob0pOqXklgUJU2AG6pq8TG6SWTraxXtpVW
+# GPf2BtcayBqOWjkV440MLR1PBRxNIHF1cQoZ4ySU1n9PfIolxhOq08Z4j9SeZzmjFiTuJMyTP4A10HYG
+# 2q4CkdvlzTwaDbt9yucUZWWFzAqh4IYcx1bp70XEYPi6JpQh8qOEe2sOCoMzxIW6WaAgavt7zqE6F6DA
+# CxX1RwCYeP56nDKQVr46jeuUwTutQ3ER2aNiVdWwsf2rzebs6TTi8YjgII08ZrF4wgJ5KxkfAaDSEJbA
+# H9hZXrAiR4i3mbTkPxiHqq38RYV0g8uvSDnDAtwmH3bA9f0yuNBtVzS2hSgrzuweik4z3k9pfYlyRES5
+# s2f9rKKvDs7jBBoV06OL4MOsb36h1JYNMdKwPthDBG133xOhXd0p6WIu5JAQRZnwEHgiGQh5aoNTrBrd
+# 54T5txmmTXajWtSPPwxumt2xR2pmnf3Iw3Hn6iedOOX3uDqKBkg9F8g5WtPgYf9Qc25qui05RKRrIwGT
+# OP3AYrRLFVs6pSnIovgFcS21k090PHhU6TA3RftILzMGxzNy0HYStKuOuMTJh24ieO78SfJ8WYYff11G
+# --------------------------------------------------------------------------------
+
+```

--- a/unreleased_changes/20260812_235102_122__1890.md
+++ b/unreleased_changes/20260812_235102_122__1890.md
@@ -1,0 +1,67 @@
+* Feature **#1890** : Add an optional sixth argument to `bitmap-lookup` to set the delimiter placed between the values of the matched bit positions. Defaults to a single space.
+
+
+```sh
+# ********************************************************************************
+# Issue number: 1890
+# Issue title:  Add arg to bitmapLookup to specify the separator
+# Issue link:   https://github.com/gchq/stroom/issues/1890
+# ********************************************************************************
+
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Bug **#123** : Fix bug with an associated GitHub issue in this repository.
+#
+# * Bug **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository.
+#
+# * Feature **#789** : Add new feature X.
+#
+# * Bug : Fix bug with no associated GitHub issue.
+#
+#
+# Note: The line must start '* XXX ', where 'XXX' is a valid category,
+#       one of [Bug Feature Refactor Dependency Build].
+
+
+# --------------------------------------------------------------------------------
+# The following is random text to make this file unique for git's change detection
+# L5nW0BzeWNioqWcVQybXetIBbb8CE4RSldJcVylE3dB6f9zU08WHbZlvmgNgAmDylBe07sUK5XPxs1GI
+# GwEP6ZvfpDQ0g8iMjgkARQ0S9grGF7bTMHvJjhrqgc6f1gS5UHosMvIYLTmTxsL5gXwUMzyoswZ5OgWZ
+# WGsAeRmyKf4lcYl7vAXe2V7uFuCVyy76WN29LJMDf2OAkUsHruTujP9PIAy356ikWT7TIvxwX5Th22kS
+# rcbYLO0OEeVVVcCHB4nGaeR15OsUP8BPEMEh8OjrfFlSFootnGK7WfvSe2DHG7FtT2gKxi6IBuqkj76w
+# PYZDigM4HuMHU7N4s8GCaMeMmF4GjkDXFcX1PyvFhFEy8PGpzQbaW0tSOiYCgxQMhnaWQZ1KXGygYXU0
+# NrvdtcGa2RXuW5UlmnU7FayNzjnVJ2AHgUW4kJowxsagxVyLCT6uHFpnkWXwlBMXhNG8hJwmFjZnZ2X5
+# shOmLM4Mb7EIMFeSuELohci52lsO94m0tAIEjyFcheD2aufWIOldhgxgy6v6DpkJ7en9BX8swhe8qepI
+# wx4O7ih2OzJ2NeI4UfoUYshYLZyCLiMScqRXGVzDunbkdr3WUYUiDvQDMPV88IZmodKNXINcIgt3Rz0o
+# pPrkojrdedzBhbDwEpu1r7lsmP9WiPr1KsB1FfRzOH5cEsqtv2MFG3lBvuB0opgT4m4rXFyFGGyhPL7u
+# Z9qfgow1vGrmUePdMkSz0yY0gfjk8iS7eemeXe3niqbparMQdZxOFA5ryY6a66PabnjFpCwLQUScFrlA
+# e1TKM46u9PxBH7pFbaWS6tKsQykujQd4vZo4oaqcqbH2urxCAKClykhTnPbBts9KMDtSvgxbLwy2E9kT
+# aQbvdYzg1F64Egdh2w4JWvhF5xQBShJz7HK1DGzOB0WXL2V2HouQjNVEPSW0AeR4BMT9NeMmPw8QpkWc
+# SK73GwnNLyue3Zeh1eW7hkKZocsF72G0irwwI5dtxsVI3picyhzm7cfCPZ92W2eXRAhYnwUxn7aErP60
+# fbxDHmcCNCOvsG1llIoPhdSk5iJvsknJGNfmuqCauo5WEVA7fwTswsdwgZAZC76fWGa2PcujMQeDL4jC
+# Ik5hpsQC4wmUwZAC91dxF1Ovxc0M6ktqteoumMPrmHgI9SBn4q7PfWQN3VaE6CNs3AthW8cyhjJDgohC
+# ISHLTD0ZJmQdzLus4rsNYGLzUaw4NzfTtPyClzI91TeszA8lZDsUehjpovah3hG9O7t1qtwkCldA5bpq
+# HXfshRwxk9EfJiTCq6hHcW8Ro6ZvEaAXljq3nAvbcfrI9XeU5es4dMea2YgoUnNsx3uV7hBaKC5OOkZv
+# 6vAXPIdNJOXC9phoMd8FhqyOnRDRShc3jKIQY60zHPHvlEYUAFTF3bdsCWtM3lWi7xoNGwtqIglGrJiJ
+# 53MCtmvzcZca9rx8Q9V3nXirGBFGx6NTRDZIX0SMflX1T6VeRIhYHkUGObK8153F3t5L2A9gYdZeK2O6
+# kaEpWlQgxH5dMtBLSWPEBn61u5PE4Vhld8Hf0KqA2W5AWM8FH4SNr2V5HPNn1W7mz4VG88IH81MM2SCE
+# upqHHU7jha9obJDV9crYGvD2F4tq8CXuZgP5PTChmXqsOI0m560p8wj38mR454pV8c00xzzwoHoGPKik
+# 2L8Kshlpq9265CqSV3jD3ANPxQGrcuyPVsytkBvnY8j9voyajqN5npgWcapKE5BQoNVpTDbC5AhqC50Q
+# zH6WyHFGjw0m8bWg1676A3BOAUIucCbeOoyXkhuS3bLXNU6EvnwEn3O1MKiCdjOO7pVdzNPzd9IdryGW
+# hWSyqCvKsfFjEZI1yR6027tcEIYhnPNIoPz2KnJD4nK7HmecT9k2bxXzM6Mk64fNC71lrG2PpcUYkItz
+# FDGTgF0y5owo8LM8WaYPmfY87IIjgLzZgxg0bzaVaejaPhR45LL1Fo3kDTEse2PKTDRSEPHKv5LuUZkP
+# XGrYcahYGBtEINd4nxx1TrRm4bXFPeSlWk3ttfGFT8B4Of9IGPkSyxoIbMFuK6szLV8En9WgnoJAZg3z
+# A4womBivKQEIPumZmI4Wpdl3xz267D42GxZ8CT71yythsJXCOeUyGuwAZbbJ2veWNJy3C1s8PSyD0Qay
+# pamuROuxH0tvpmHTLW5QpJKwq172Zpw91Xm6nTNfaRzi3sCWx9Fxq9xCkZMr1kfnX25mi0UuHEvvdusF
+# ElFwYtFgjI5TvvSi8uvPgmt8URO61ijhOpCYuyl6pHNfi5Kz7Ok3wpesYGDgslINQ5eqTScOnn35KYPf
+# JH8NuFvzCTAXBcZAt4Td1wGeh8G2UzXpUsfPtojggbCBCbcJ3W2uAqEY9fV5OE0QhHrRrmzg8kB3c3cj
+# --------------------------------------------------------------------------------
+
+```


### PR DESCRIPTION
Fixes #5713. Related: #1890.

`stroom:bitmap-lookup()` returned the values of the matched bit positions concatenated
with no delimiter (`Manage_UsersView_DataManage_Volumes`), despite the
[documentation](https://gchq.github.io/stroom-docs/docs/user-guide/pipelines/xslt/xslt-functions/#bitmap-lookup)
stating the result is a space delimited list (`Manage_Users View_Data Manage_Volumes`).

### Cause

Each matched bit position's value is consumed into a single shared Saxon `TinyBuilder`
via consecutive `Receiver.characters()` calls, which coalesce into one text node with
nothing between them. The existing comments in `BitmapLookup.lookupBit()` and
`StringByteBufferConsumer.consumeBytes()` speculated a `' '` was being added implicitly
deeper down — it is not.

### Fix

`SequenceMaker` now wraps its `TinyBuilder` in a small `ProxyReceiver`
(`ValueDelimitingReceiver`). `consume()` marks a logical value boundary; the receiver
writes a single space **lazily**, only when the next value actually produces output.
A bit position that matches nothing therefore cannot produce doubled or trailing
delimiters. Plain `stroom:lookup()` consumes one value per `SequenceMaker`, so it is
unaffected. This also gives #1890 a single obvious place to hang a configurable
separator arg later.

### Tests

Written red-first against the unmodified code:

```
expected: "Manage_Users View_Data Manage_Volumes"
 but was: "Manage_UsersView_DataManage_Volumes"
```

New tests in `TestBitmapLookup` drive `bitmap-lookup` through a **real**
`SequenceMaker` (real `TinyBuilder` + real on-heap value consumers), covering:
multiple matched bits are space delimited; an unmatched middle bit produces no double
space; an unmatched last bit produces no trailing space; a single value has no
delimiter. `TestBitmapLookup` 11/11 green; full `:stroom-pipeline:test` suite green
(836 tests, 0 failures); `./gradlew build -x test` (compile + checkstyle, all
modules) green.
