### PR TITLE
Fix content pack import env var name in the stroom docker image

### DIFF
--- a/stroom-app/docker/Dockerfile
+++ b/stroom-app/docker/Dockerfile
@@ -49,7 +49,7 @@ FROM stroom-base-stage
 
 # IN_DOCKER tells setup.sh to run Configure without asking for user input, i.e. using defaults.
 ENV IN_DOCKER="true"
-ENV STROOM_CONTENT_PACK_IMPORT_ENABLE="true"
+ENV STROOM_CONTENT_PACK_IMPORT_ENABLED="true"
 # Needed to fix 'Fontconfig warning: ignoring C.UTF-8: not a valid language tag'
 ENV LANG=en_GB.UTF-8
 

--- a/unreleased_changes/20260819_075323_708__0.md
+++ b/unreleased_changes/20260819_075323_708__0.md
@@ -1,0 +1,65 @@
+* Bug : Fix the `STROOM_CONTENT_PACK_IMPORT_ENABLE` environment variable in the stroom docker image having no effect. The config template reads `STROOM_CONTENT_PACK_IMPORT_ENABLED`, so the image's variable never matched and content pack import stayed disabled.
+
+
+```sh
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Bug **#123** : Fix bug with an associated GitHub issue in this repository.
+#
+# * Bug **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository.
+#
+# * Feature **#789** : Add new feature X.
+#
+# * Bug : Fix bug with no associated GitHub issue.
+#
+#
+# Note: The line must start '* XXX ', where 'XXX' is a valid category,
+#       one of [Bug Feature Refactor Dependency Build].
+
+
+# --------------------------------------------------------------------------------
+# The following is random text to make this file unique for git's change detection
+# UdTbSd6WkyILkbNZbgyUN6BBvJSJgRW5njAv3JPZD5MlhK5V6KgnVb21GQIx2xaH9E9woenXM9spNJ5a
+# A18WPYOF7WEAvFNebBvpeFsZkFyOqm7c4enEx6BYaU5zqVi4eWwhAx9GO5V8ODfCx6emBK1HC8SMlbr5
+# mPjpOkmbnUKMw3Bi5tO41pIRUpbU3v5OdDpx0EDVGfk5dRVvuztezecjYz2mu5oFCRQPhsqBmjW3Gitw
+# ODQPMfoHxCtQRLsxlfV3onv78WiN7eOHyS1ZCwDBw6WM2DHC0KXrry23VFWbW94Toi8S9WgeViR85Kiq
+# fVh0oNYu7CN4gZ2fPy4CWGafpauXKyw1B2G6PDTgZrNgxKJ4b1aXM1KZMG2Q1F2XRZpx7MYHEvONwEP0
+# KXA6dMtOaw6wa0zTizUa9uKdjRnz45u3tHWwGDGMNqCYPanigyp3gBUO3NNeNCZX157tk2j7wKK476Lh
+# zfW3LOhcpWxNSnEGVd7kaGTB3Ke1mqXue722YUEXagAvlUGLiWrE7tWa869vSRqADxR3NDby7h1SoAvV
+# YdrZbu7i3FKYDkrzqq8Zev0V3E9TuGe7KnoG7vHbzcBUwm4Bh6SuQJt0acXaC6Jk5oMrH0H3MrZSVfYA
+# FQzijP8NQjJyNpOTCDceUrsisvj4WzvAJF3kRktKhtyim7wXYq3Dkm9ZGkEwhvwpyagRWcqZpOPyBr0y
+# SFbcw6WepvML0rxQeuLZxKAWtZg2mJUDXjItP0YmQf2GdsgPYUJSbrLwCYpOzSQ8qh8kam6axClE33EY
+# TRaFwlaqPSp2ItL4XwD2pVcKvgGdH1g9SO9T9J8vp5snViVd9iGtZLQcspyiM4pN9uTos6Y8oyXN5vmx
+# hAGtkvAikFicRRwh6r5ZzUDSPgtxV8FC8EK2onMlDEmb6t8xsMkaaRGdLB83nMFAs1QdohN4JfQiRTBC
+# RxoHbTk91nbepYTmpDJdBmgxyXccwjN24d58bug0N6MBxgr9EmEoJQltNFBGhP8PHqGMbBjuJYj3yGHG
+# wnFG9pWvYgm7OdxQx9TdHmR3WnhYCFYX8GLren5e2uOLC5cua9UDamK2s2MeEiizY9yMdgitLdW6CkPD
+# MuVxy0t21eui8CCebvEUj3x3kMIazbwV6Kk55JUnnjQaDAnhXYMrd1LsAqkxJCk7i4VSq23i7P6nG4Lg
+# wpKl6zg1ZdE8oeYxhsbrDAvKGEyZQvok3i5kITRsY0BAbJuqmDR8zgkBGdrYl5uhe5xAgXfwvVq8dl7I
+# hh7JznxcGOM4A3qyM1Naa9iVeZpu9pyzJfzXC94nhu31DLy2AOTJCcEpqXMellYl3jzKNVsm77CDsdQX
+# WSrmTPcSErrYjOwrstVuEtGN8q592Whr3Lmcj9yWTXXP1S2OZDJzGj00vOZhMoEyFG5JkaFV1tm4ZqT1
+# Il2tMWm7Psfr2JcYm0BJGEBpStILhxRfM2mtZ2Dzxo9Xa1A0w4LjuAE8pR6pz4Q9gdfAjGUy0O6v24pg
+# QeavpPpIi59xdbIjz5cUE7B5kW1dofwzR0DKk6c7F6iQEDT8E6AkKCLs1TI2TULhzvhe5Hzd8s8b75Tb
+# UzOHRSvsbZhA0k4kzXFb0xf6s7UBo74v6ffA7uuYFrDhfG0cFDCvnVTk3yR3D4RARQuWti5AJG1mnouK
+# yfGTD7qNwDagNcjEyz7gIJKeX2PC1QWaWrKp1cpCrpKpZYAG1Ed8LRQ66Lkt8ETN23a56HVIzsheOZeN
+# N317j4K8kl7p59LNyfLelq1qjICnWygfFBxLRV29DBaw4yvvak0Q5t2TEGu1DfYZKpB636XSyJFzdFGq
+# 1NXMzx9mz44Lci6qDyrEs0CpuLnhR04LSHwVjZWs0nmWMfKj2aTayeChBLdOPy6eXRHIEATqnsCMbxjY
+# UpKlXUAqxLRAcOXwakjC7UXiUxVsEdHJCxctilhvkDVOdtpN6esTGIb3yLpnRW2AgRyRECfF3ocrhUnB
+# pkti7GGOkVN9CsYog2GWxiXa06DJnPVktm96VAjgVZyUvL9Ku6zZzis4tUNtNCfYkwsmGhuiSKtAIgyM
+# 2SFfidd8WwsfmvvjqF5iTfqjWh2H3rVqs6y9xrJXcXfsECidjhsQaREbmKeGRpybKVwTBJocXBClaRcM
+# WURE8AVOYN1RA19GpeB1ffXY5F9rUk8yCZpDFgHvFqqjmrpyDhuMLjsVRsbsPcUbWDgf8BxL2izRybjN
+# QFABWDxlPsm21757k0GxzdjrPzMTLvkqyuye2J7tCRAoqFe2HwCY1vVdpEkasymaE8uhlIirz2yN66lp
+# 8V0ZNVHVBAcST6wIVIM2PwgnvTzralic5JAnsy2GSKbJVxIyL18LLW5SiOAwc2ZOg9x4URp3ATvXF4kl
+# m0uPfzGNqJiZ1hjWU6j3gw1u9RY6mwdJiXtAf9ToHDIN4JdmGZRHCUn6WGDCYFix0TkOMDjLV2PSXwz3
+# s0xmqkU8kqYPWRzcTvH9hxKbUxGr5FinzlmLdvvTupSimWZqcFJDafzwjXAsO0xWzXkU2qBwQN6EEboo
+# gAkXjxhMnETgF4JSEHCNArGvaRxDFP3X8Sti0vqnn6iIMj4FVhxSWOJp6K6YfZo1wkotnPAylFlgmqYr
+# hyCSQZPsxqC6GlMxQXOLmFHSvNYGeqRoP5k3AcwEk7gcHFxbgoBXPoDvAUuu64SQCf09zzqDktZvbL9e
+# --------------------------------------------------------------------------------
+
+```


### PR DESCRIPTION
The stroom docker image sets:

```
ENV STROOM_CONTENT_PACK_IMPORT_ENABLE="true"
```

but `stroom-app/prod.yml.jinja2` reads a different name:

```
enabled: {{ false | envVar("STROOM_CONTENT_PACK_IMPORT_ENABLED") }}
```

`ENABLE` vs `ENABLED`, so the variable the image sets is never read and
`contentPackImport.enabled` falls back to its default of `false`. Content packs
staged in `/stroom/content_pack_import/` are not imported, and nothing errors.

This renames the variable in the Dockerfile to match the template.

Noticed while deploying the image to Kubernetes: the container starts with the
packs present and unread, and `SELECT COUNT(*) FROM doc` stays 0.

stroom-proxy is unaffected — its Dockerfile does not set the variable.

Setting `STROOM_CONTENT_PACK_IMPORT_ENABLED` explicitly is a workaround on the
current image.