### PR TITLE
Guard incomplete rerank field pairs

### DIFF
--- a/stroom-index/stroom-index-lucene/src/main/java/stroom/index/lucene/RerankScoringFilterFactoryImpl.java
+++ b/stroom-index/stroom-index-lucene/src/main/java/stroom/index/lucene/RerankScoringFilterFactoryImpl.java
@@ -121,7 +121,7 @@ public class RerankScoringFilterFactoryImpl implements RerankScoringFilterFactor
                 final String denseVectorFieldName = entry.getKey();
                 final FieldRef fieldRef = entry.getValue();
 
-                if (fieldRef.scoreField.index != -1 && fieldRef.valueField.index != -1) {
+                if (fieldRef.scoreField != null && fieldRef.valueField != null) {
                     final IndexField denseVectorField = indexFieldCache.get(indexDocRef, denseVectorFieldName);
                     if (denseVectorField == null) {
                         throw new UnsupportedOperationException(

--- a/stroom-index/stroom-index-lucene/src/test/java/stroom/index/lucene/TestRerankScoringFilterFactoryImpl.java
+++ b/stroom-index/stroom-index-lucene/src/test/java/stroom/index/lucene/TestRerankScoringFilterFactoryImpl.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stroom.index.lucene;
+
+import stroom.query.common.v2.ErrorConsumerImpl;
+import stroom.query.language.functions.FieldIndex;
+import stroom.test.common.util.test.StroomUnitTest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestRerankScoringFilterFactoryImpl extends StroomUnitTest {
+
+    @Test
+    void testMissingScoreField() {
+        final FieldIndex fieldIndex = new FieldIndex();
+        fieldIndex.create("vector__rerank_value");
+        final ErrorConsumerImpl errorConsumer = new ErrorConsumerImpl();
+
+        final var filter = new RerankScoringFilterFactoryImpl(null, null, null)
+                .create(null, null, fieldIndex, null, errorConsumer);
+
+        assertThat(filter).isEmpty();
+        assertThat(errorConsumer.hasErrors()).isFalse();
+    }
+
+    @Test
+    void testMissingValueField() {
+        final FieldIndex fieldIndex = new FieldIndex();
+        fieldIndex.create("vector__rerank_score");
+        final ErrorConsumerImpl errorConsumer = new ErrorConsumerImpl();
+
+        final var filter = new RerankScoringFilterFactoryImpl(null, null, null)
+                .create(null, null, fieldIndex, null, errorConsumer);
+
+        assertThat(filter).isEmpty();
+        assertThat(errorConsumer.hasErrors()).isFalse();
+    }
+}

--- a/unreleased_changes/20260910_143434_619__5773.md
+++ b/unreleased_changes/20260910_143434_619__5773.md
@@ -1,0 +1,68 @@
+* Bug **#5773** : Handle incomplete rerank field pairs without a null pointer error.
+
+
+```sh
+# ********************************************************************************
+# Issue number: 5773
+# Issue title:  Dense Vector searching ERROR:
+# Issue tags:   f:dash / query
+# Issue link:   https://github.com/gchq/stroom/issues/5773
+# ********************************************************************************
+
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Bug **#123** : Fix bug with an associated GitHub issue in this repository.
+#
+# * Bug **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository.
+#
+# * Feature **#789** : Add new feature X.
+#
+# * Bug : Fix bug with no associated GitHub issue.
+#
+#
+# Note: The line must start '* XXX ', where 'XXX' is a valid category,
+#       one of [Bug Feature Refactor Dependency Build].
+
+
+# --------------------------------------------------------------------------------
+# The following is random text to make this file unique for git's change detection
+# 09azXG5oOpES9abRaUSUWlYrGuhJOWwPlC9qF2xy5aOQqfHJBUOLJJi2d6LJUhjUuhbMB6icO32A48mE
+# B9907grK4g8OKOoyCfUTaPk3lMYN4Z0LPQfaNnjhaYq0Gv5bfFnlR9GmRi1sEg8KTurOIhVpZLnbXmCF
+# Aad4U8qsFKrh5mZsr49uJySwsBgwYU3HCbdg6C84TbnB635bdsULkPlpo7tY6khfvSX8G9hys46FqdW4
+# h03Ica27NELym1RZBlCjiv06nrtIxZsk0KIqtx80n61jkgdmxIpOsUlVtMlgyK0LEtiF8ujFn4m0YLvW
+# AfA0STH962uuUzvqkPUStExtfxCVGOanPoOS8KPnqefjtHmZnXTgHzSHoSI6RB81ilcCiQAth064OzYH
+# z0Id2kALeLSgyfvTNPQ0rNtX7S8qIgBfczqVRYmAOseeRuHvfMjyI1z1wLLqrJHzAIb0nDqhpgatxJWa
+# AcjGKMG9xHYrBWBHDGqVoUuwY3P965kXaNb3IFiFhhaY0ShubYqoFXO4CSey53cNME5oScmcr6CF30or
+# DfSDOxboH2h5ykf8R7KaUy1NkOH7NG8vGDU0Ubm1xUuB07f9qoKFLLqfLsKvcA84nCKBLNdZFX07eBeK
+# LC3SLzmsu0Cd5QIieosYZi9IuL0ZY3JVEWV7cVU3GCe6G9c9AsdBPfSoTDKknLOocr5AT2f1QiRe4287
+# LA57oN6RyeujabvlPisa2LOXv3JzEUujaWEdaakxA31g7LpWJIxWJkHtRRcwFsIxq1tG98YQlQIECWKi
+# 8xVKo8YPk6Z0plVUCKrV5RutsvEA4ypGxr5HrapN0Xat1cUI1HHbyBMvMPfYol12aA6k0kxIx3fPjqQ6
+# YaNaON1I3yp5NEzLejBTm90ifinbD4KZTbURsrrtIa1gdhqXWRHcucAigKEAwzWInGjOTBaOGTsd5roz
+# shoREVzIAQ7vISFbHC94TM8PdvTR8MXfBPkVrMRGVjoydUaiOlOC5W1ihity1Se4rOh2QACXKNXwqWWz
+# cjW0m2v3VqMn2smV4rVGJ2IOdrC07KmYL81SwjxhSy4aPHEGFM31gx8ZGxr7FeOwtBJaVwtWQQVTIcR5
+# qy1qtqfycGTdp0iJroBqtI2Ngt66M91M1ZKjx3jBl7usZdQyXAeMiS7cLqUJDuBs14FiSK0cOHp23LOj
+# M21E0MkcUb6zun79Xq9ujCoPyJGKCIorSfNvD0jHDhA991HtYuqx54Githc09AnbHUEz5PpGWlzPn4Rg
+# OepUAHZ4bmKB6Ud8vKxpkbIbKryNsGpMDMP5SyRNpE6Rtbw18Yo4i76aicAI0L4BPwu5QW2BIE0VH4HA
+# 7Mivm8uOZzz0S7hZMIaxgT8yU9bjXL1VZ114lhgg3SD5OtKuF4rzJsNeNd0HSXPCyqWR0h9I0JbzAgGd
+# IN9avmyc6BKhRmj9cVfBHgcs7u4DyZ8JUOTyGp0XnJ36aba2z0YZraE1SFNAQOQO4ZgiptPNeIIO4Otm
+# nZlg6NaNsUkzqBrQvNBclb2jRQfBiVpOCHZjzGmJ6nYPAHasCGkYjNcR1Zp9huALdHsXhy8j2KzRuHOf
+# db2r9E1k2SAPFCl2qUwIDpgMtuw6aQt7x01BfrfqQh52dyxM5OnI3YzUCVZobGAJ4NRqyrTmW1GiOuTF
+# Xu590j0zfG1f9gd4F0LcKL4w4gt0NjhkdO20mcu6gqyEjDaXzCf8XoF0lwDOlitSxg9Tz9h7p9J2KfSV
+# cgYL6tDabjib9kV1l5EFLBX06v28hdNWFkyBgwQpIbfsYYRfVL82Ph4Bgc6LgZxqUphnAo2UBFkoq11V
+# LNJqxCG0Dd8TgiMFAV2qd69BkJ8NDfkauP7ZNdKSofZRdNfNTqBVogBqN38fDSqzi3QoipufqaZYkbNV
+# ytZZfLSHZUdt2fqu0FdvoGfqZEWAEcVFrcGEIooQAgOSTMo1SyTHPTrn1dBzJthauXGI4dEuGVEAcqQL
+# 4p2VEDz253RxLx8QRS9Gk66qtLBfZ7DKVvPbgOncwheeQABv1DRYwXuNb71qylomPP0rxetsDHcObdED
+# XsoeZIR4SvsEEPI1wyhAByIpa0SocW6i4AIOnNITq0aY9DrSIcBE5jReHaGNqHNdujpKvV0PD4WUli0F
+# FFia2DSSmojkjsaM1Ql7EwoxUT3DeO1KLiuEWthKdaUeemB2TAWuAkspGzAPSmM8El3iGkhIXbCb4rlF
+# 8vd0XlgzmmPnmMMz0jYIKf8igi9ydnRK3uFJpgbzIc2v2lAPYq0HrHpWbwooZLlorNkNqiiY8rdY8Eei
+# arIrKVRo0xaSepPe9bBmesltwaNKGFoq7nf4FYn09qM4s3SCzTQH4wlnDd1Plo1n7xze5zUAHow14By3
+# --------------------------------------------------------------------------------
+
+```


### PR DESCRIPTION
Fixes #5773

Avoid dereferencing a missing rerank score or value field when only one half of the generated field pair is present. Adds regression coverage for both incomplete-pair cases.

Tested with:
`./gradlew :stroom-index:stroom-index-lucene:test --tests stroom.index.lucene.TestRerankScoringFilterFactoryImpl`