### PR TITLE
Add help tooltips to data info keys

### DIFF
--- a/stroom-core-client/src/main/java/stroom/data/client/presenter/DataPresenter.java
+++ b/stroom-core-client/src/main/java/stroom/data/client/presenter/DataPresenter.java
@@ -1152,8 +1152,17 @@ public class DataPresenter
                     .forEach(entry -> {
                         final String key = entry.getKey();
                         final String value = entry.getValue();
+                        final String helpText = entry.getHelpText();
+                        final SafeHtml keyHtml;
+                        if (helpText == null || helpText.isEmpty()) {
+                            keyHtml = SafeHtmlUtils.fromString(key);
+                        } else {
+                            final HtmlBuilder keyHtmlBuilder = new HtmlBuilder();
+                            keyHtmlBuilder.span(key, Attribute.title(helpText));
+                            keyHtml = keyHtmlBuilder.toSafeHtml();
+                        }
 
-                        tableBuilder.row(SafeHtmlUtils.fromString(key), toHtmlLineBreaks(key, value));
+                        tableBuilder.row(keyHtml, toHtmlLineBreaks(key, value));
                     });
         }
 

--- a/stroom-core-shared/src/main/java/stroom/data/shared/DataInfoSection.java
+++ b/stroom-core-shared/src/main/java/stroom/data/shared/DataInfoSection.java
@@ -58,12 +58,21 @@ public class DataInfoSection {
         private final String key;
         @JsonProperty
         private final String value;
+        @JsonProperty
+        private final String helpText;
+
+        public Entry(final String key,
+                     final String value) {
+            this(key, value, null);
+        }
 
         @JsonCreator
         public Entry(@JsonProperty("key") final String key,
-                     @JsonProperty("value") final String value) {
+                     @JsonProperty("value") final String value,
+                     @JsonProperty("helpText") final String helpText) {
             this.key = key;
             this.value = value;
+            this.helpText = helpText;
         }
 
         public String getKey() {
@@ -72,6 +81,10 @@ public class DataInfoSection {
 
         public String getValue() {
             return value;
+        }
+
+        public String getHelpText() {
+            return helpText;
         }
     }
 }

--- a/stroom-core-shared/src/test/java/stroom/data/shared/TestDataInfoSection.java
+++ b/stroom-core-shared/src/test/java/stroom/data/shared/TestDataInfoSection.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stroom.data.shared;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestDataInfoSection {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    /// Reads entries produced before optional help text was introduced.
+    @Test
+    void testReadLegacyEntry() throws Exception {
+        final DataInfoSection.Entry entry = mapper.readValue(
+                "{\"key\":\"Feed\",\"value\":\"TEST-FEED\"}", DataInfoSection.Entry.class);
+
+        assertThat(entry.getKey()).isEqualTo("Feed");
+        assertThat(entry.getValue()).isEqualTo("TEST-FEED");
+        assertThat(entry.getHelpText()).isNull();
+    }
+
+    /// Leaves help text absent when the existing two-argument constructor is used.
+    @Test
+    void testOmitAbsentHelpText() {
+        final JsonNode json = mapper.valueToTree(new DataInfoSection.Entry("Feed", "TEST-FEED"));
+
+        assertThat(json.path("key").asText()).isEqualTo("Feed");
+        assertThat(json.path("value").asText()).isEqualTo("TEST-FEED");
+        assertThat(json.has("helpText")).isFalse();
+    }
+
+    /// Preserves optional help text through the nested section response format.
+    @Test
+    void testRoundTripHelpText() throws Exception {
+        final String helpText = "The feed's name, including <tags> & \"quotes\".";
+        final DataInfoSection section = new DataInfoSection("Stream", List.of(
+                new DataInfoSection.Entry("Feed", "TEST-FEED", helpText)));
+        final DataInfoSection copy = mapper.readValue(mapper.writeValueAsString(section), DataInfoSection.class);
+
+        assertThat(copy.getTitle()).isEqualTo("Stream");
+        assertThat(copy.getEntries()).hasSize(1);
+        assertThat(copy.getEntries().getFirst().getKey()).isEqualTo("Feed");
+        assertThat(copy.getEntries().getFirst().getValue()).isEqualTo("TEST-FEED");
+        assertThat(copy.getEntries().getFirst().getHelpText()).isEqualTo(helpText);
+    }
+}

--- a/stroom-data/stroom-data-store-impl/src/main/java/stroom/data/store/impl/DataServiceImpl.java
+++ b/stroom-data/stroom-data-store-impl/src/main/java/stroom/data/store/impl/DataServiceImpl.java
@@ -263,7 +263,7 @@ class DataServiceImpl implements DataService {
         final List<DataInfoSection> sections = new ArrayList<>();
         if (metaRow == null) {
             final List<DataInfoSection.Entry> entries = new ArrayList<>(1);
-            entries.add(new DataInfoSection.Entry("Deleted Stream Id", String.valueOf(id)));
+            entries.add(infoEntry("Deleted Stream Id", String.valueOf(id)));
             sections.add(new DataInfoSection("Stream", entries));
 
         } else {
@@ -296,15 +296,15 @@ class DataServiceImpl implements DataService {
                     !DataRetentionFields.RETENTION_RULE.equals(key)) {
 
                     if (MetaFields.DURATION.getFldName().equals(key)) {
-                        attributeEntries.add(new DataInfoSection.Entry(key, convertDuration(value)));
+                        attributeEntries.add(infoEntry(key, convertDuration(value)));
                     } else if (key.toLowerCase().contains("time")) {
-                        attributeEntries.add(new DataInfoSection.Entry(key, convertTime(value)));
+                        attributeEntries.add(infoEntry(key, convertTime(value)));
                     } else if (key.toLowerCase().contains("size")) {
-                        attributeEntries.add(new DataInfoSection.Entry(key, convertSize(value)));
+                        attributeEntries.add(infoEntry(key, convertSize(value)));
                     } else if (key.toLowerCase().contains("count")) {
-                        attributeEntries.add(new DataInfoSection.Entry(key, convertCount(value)));
+                        attributeEntries.add(infoEntry(key, convertCount(value)));
                     } else {
-                        attributeEntries.add(new DataInfoSection.Entry(key, value));
+                        attributeEntries.add(infoEntry(key, value));
                     }
                 }
             });
@@ -408,22 +408,22 @@ class DataServiceImpl implements DataService {
     private List<DataInfoSection.Entry> getStreamEntries(final Meta meta) {
         final List<DataInfoSection.Entry> entries = new ArrayList<>();
 
-        entries.add(new DataInfoSection.Entry("Stream Id", String.valueOf(meta.getId())));
-        entries.add(new DataInfoSection.Entry("Status", meta.getStatus().getDisplayValue()));
-        entries.add(new DataInfoSection.Entry("Status Ms", getDateTimeString(meta.getStatusMs())));
+        entries.add(infoEntry("Stream Id", String.valueOf(meta.getId())));
+        entries.add(infoEntry("Status", meta.getStatus().getDisplayValue()));
+        entries.add(infoEntry("Status Ms", getDateTimeString(meta.getStatusMs())));
         addEntryIfPresent(entries, "Parent Stream Id", meta.getParentMetaId());
-        entries.add(new DataInfoSection.Entry("Created", getDateTimeString(meta.getCreateMs())));
-        entries.add(new DataInfoSection.Entry("Effective", getDateTimeString(meta.getEffectiveMs())));
-        entries.add(new DataInfoSection.Entry("Stream Type", meta.getTypeName()));
-        entries.add(new DataInfoSection.Entry("Feed", meta.getFeedName()));
+        entries.add(infoEntry("Created", getDateTimeString(meta.getCreateMs())));
+        entries.add(infoEntry("Effective", getDateTimeString(meta.getEffectiveMs())));
+        entries.add(infoEntry("Stream Type", meta.getTypeName()));
+        entries.add(infoEntry("Feed", meta.getFeedName()));
         addEncodingInfo(meta, entries);
 
         final DataVolume dataVolume = dataVolumeService.findDataVolume(meta.getId());
         NullSafe.consume(dataVolume, DataVolume::getVolumeGroupName, grpName ->
-                entries.add(new Entry("Volume Group", grpName)));
+                entries.add(infoEntry("Volume Group", grpName)));
         NullSafe.consume(dataVolume, DataVolume::getVolumeType, FsVolumeType::getDisplayValue, typeName ->
-                entries.add(new Entry("Volume Type", typeName)));
-        entries.add(new DataInfoSection.Entry("Read-Only Data",
+                entries.add(infoEntry("Volume Type", typeName)));
+        entries.add(infoEntry("Read-Only Data",
                 (meta.isReadOnly()
                         ? "Yes"
                         : "No")));
@@ -435,7 +435,7 @@ class DataServiceImpl implements DataService {
         final List<DataInfoSection.Entry> entries = new ArrayList<>();
 
         NullSafe.consume(meta.getProcessorUuid(), uuid ->
-                entries.add(new DataInfoSection.Entry("Processor", uuid)));
+                entries.add(infoEntry("Processor", uuid)));
 
         if (meta.getPipelineUuid() != null) {
             final String pipelineName = getPipelineName(meta);
@@ -444,7 +444,7 @@ class DataServiceImpl implements DataService {
                     .name(pipelineName)
                     .build();
             final String pipeline = DocRefUtil.createSimpleDocRefString(docRef);
-            entries.add(new DataInfoSection.Entry("Processor Pipeline", pipeline));
+            entries.add(infoEntry("Processor Pipeline", pipeline));
         }
         addEntryIfPresent(entries, "Processor Filter Id", meta.getProcessorFilterId());
         addEntryIfPresent(entries, "Processor Task Id", meta.getProcessorTaskId());
@@ -456,7 +456,7 @@ class DataServiceImpl implements DataService {
                                    final String entryName,
                                    final Number value) {
         if (value != null) {
-            entries.add(new DataInfoSection.Entry(entryName, String.valueOf(value)));
+            entries.add(infoEntry(entryName, String.valueOf(value)));
         }
     }
 
@@ -470,15 +470,46 @@ class DataServiceImpl implements DataService {
                             // If this is the received stream type then show the encoding
                             if (metaService.isRaw(meta.getTypeName())) {
                                 NullSafe.consume(feedDoc.getEncoding(), encoding ->
-                                        entries.add(new Entry("Data Encoding", encoding)));
+                                        entries.add(infoEntry("Data Encoding", encoding)));
                             } else {
-                                entries.add(new DataInfoSection.Entry(
+                                entries.add(infoEntry(
                                         "Data Encoding", StreamUtil.DEFAULT_CHARSET_NAME));
                             }
                         },
                         () -> LOGGER.error("Can't find feed doc with name " + meta.getFeedName()));
     }
 
+
+    private static DataInfoSection.Entry infoEntry(final String key,
+                                                   final String value) {
+        return new DataInfoSection.Entry(key, value, helpText(key));
+    }
+
+    private static String helpText(final String key) {
+        return switch (key) {
+            case "Deleted Stream Id" -> "Identifier of a stream that has been deleted.";
+            case "Stream Id" -> "Unique identifier for this stream.";
+            case "Status" -> "Current processing status of this stream.";
+            case "Status Ms" -> "Time the stream status last changed.";
+            case "Parent Stream Id" -> "Identifier of the parent stream this stream was derived from.";
+            case "Created" -> "Time this stream was created.";
+            case "Effective" -> "Effective time assigned to this stream.";
+            case "Stream Type" -> "Type of data stored in this stream.";
+            case "Feed" -> "Feed associated with this stream.";
+            case "Data Encoding" -> "Character encoding used for the stream data.";
+            case "Volume Group" -> "Storage volume group containing this stream.";
+            case "Volume Type" -> "Storage volume type containing this stream.";
+            case "Read-Only Data" -> "Whether the stream data is read-only.";
+            case "Processor" -> "Identifier of the processor that created this stream.";
+            case "Processor Pipeline" -> "Pipeline used by the processor that created this stream.";
+            case "Processor Filter Id" -> "Identifier of the processor filter that created this stream.";
+            case "Processor Task Id" -> "Identifier of the processor task that created this stream.";
+            case DataRetentionFields.RETENTION_AGE -> "Retention age applied to this stream.";
+            case DataRetentionFields.RETENTION_UNTIL -> "Time until which this stream will be retained.";
+            case DataRetentionFields.RETENTION_RULE -> "Retention rule applied to this stream.";
+            default -> "Metadata attribute stored for this stream.";
+        };
+    }
 
     private String getDateTimeString(final Long ms) {
         return NullSafe.getOrElse(
@@ -495,7 +526,7 @@ class DataServiceImpl implements DataService {
                             DataRetentionFields.RETENTION_UNTIL,
                             DataRetentionFields.RETENTION_RULE)
                     .forEach(field ->
-                            entries.add(new Entry(field, attributeMap.get(field))));
+                            entries.add(infoEntry(field, attributeMap.get(field))));
         }
 
         return entries;

--- a/unreleased_changes/20260910_143854_067__5743.md
+++ b/unreleased_changes/20260910_143854_067__5743.md
@@ -1,0 +1,51 @@
+* Feature **#5743** : Add help tooltips to data info keys.
+
+
+```sh
+# ********************************************************************************
+# Issue number: 5743
+# Issue title:  It would be useful to show help tooltips for the Info pane keys
+# Issue tags:   f:ui / ux improvement 7.13
+# Issue link:   https://github.com/gchq/stroom/issues/5743
+# ********************************************************************************
+
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The entry should be written in the imperative mood.
+
+# --------------------------------------------------------------------------------
+# The following is random text to make this file unique for git's change detection
+# 6r5AKkagdTyLsFFNsMW1lsRNyFezftkHcgvNupTqy5d0LnaM4PeU6pl5VzZBpMLFfqpMc9Ga3ZZINPez
+# iEEr0rfbzmF1ruVv8pZ8UCM24D1dhEwOVvv5mXIGyexCmLY0d2eDEmnu8ORN1NL9nCZMPoJKgkrIRnQh
+# MFUCIVXwoCblW2imDaefyt3B8KUTwtIsBq9BfqZghcpLokcpCQPWp75D4dJFhOTE7sr14HpAADJMhGnW
+# TgXXvUF3kO8jGX8a6CKsB6Di8U63aRuX0k6hwWpRjglZmtSWpxQk8H3Ps6y6qDUiu2lFeSVPFWtdyegx
+# O1OYhV7EkOHNYZY3moO7rHTD99h9rZCJjuuGQJ2y95SUUb0ECAbdqdtSDafLS2nyZvlX4p5SS2Tqr36b
+# LvXviT9IqizkDYpJekxQcCSS3ttuUMC7YyU5XX34UxgvlJYfcNYCimK1iq7nyRyGBnwDGvnczeTpVXjG
+# OFOVGPqBZsMkptF4aLIdLEW7oF12XuARVFMSySNsBSM5aiM3NLCzN9O6e3Ah5kfLVYGkNPK7QxFxWAcJ
+# VA6WCkc8y4v4s5ZxIMZIOKZ3echEsOC6NDyPXonJTYCd40O30n3mHhdrWdKVWLn3PoindQqqoqF2R7vc
+# dR4JQ8nN683SvJYYUP8oOP5CKjHqWsTPE2IybXQPcJRbnBfW3tokinbWXPEw6BNvT2vQdb4N9OLHwYGG
+# huSbWulz2CpXNKIiq3tDUZR2ULaQjlGZ6kVz8fADENJoXd0WRJPxsZitiNxD0GhbwEm5C6C2F3PkEoWT
+# ycPGp1iWxntI4J2t5ww9kp5nIsSrHewRmZSnq4XR2vs9dIea5JupVc5DTp4j7fV4PllPouRLmlSiAKIY
+# ewfTEInFFgbPV0UcdtD350TbJZDnx8Ly4FfZx9uCxaK3i239OGhaKKfEUuxVXTvFaU3IYXw4lVI4P9Vt
+# XE9KSVVAN3iqoTXIeIbcB9hklbtI7w0VbHk4GzcmHkFOim2dkzLEqMENPUVq1iBHByyzuidXbIkD90Gm
+# mkHzT7z8gAaufyGFrCJRqgMHDg8SkSuQlQuyv24xYE3bpXWJGbWblZO2vrx9azjnt9OfFWo34ghLXazJ
+# 8susarGpWcqLrI70EvZ33UZTkbJEW1MPA9TQVSBgMUfv03GnG5xEKOIkLAztckzPW0RyPT0cTbLsXG3K
+# 2i6CFRT4cFWqSmVbs8e2vnydcaolxjwXBDzgaPbAqCA7CNnPVPSX1uzkyrOM7r2UKouT3BeZCZhRDqDp
+# yxMwuxHCY2ueu1OTGIQd6E2775PQh3i2jbPeUrrnZeRdJAeuHzqUHusUMwyUz6HQ7gdfxltlcdtRFbEF
+# 8S8pLdoeU1pq2GQjlKZTCkLoP0biBTc8PpTWilntkq5b7EPqHIrEFGj9CzUZzYYNhhaES8fTObcxfUi5
+# DpMxpJqkvixjeCYe9WIdVgFDJJM0MKyfF2BrZoX7qUTLucDAJQV97zjkccVWSZMHMKZGEyfDIa34D1N4
+# 64xUtJAKUFGGZ4PnbkHpVXEiqDso6BwqD1iaSvDJTBWUOo7e6BYeVvrZ2UxDPI3EqMlZZ9fnlpDOEYM7
+# djT9AaGq39KTguuM5DiqCDHlDUxGCvSu2OmS6OMZ5IOOMG8ilr42FrKdZwSaVZAUbvqtp6QAxHwXdEv9
+# vYvIYFM5Jb1l9GQAcdfW77np0ZkzLEFblavQit2v1K406G5R91elV1LzEXaXb55nkK3GY5yaPNkSKkx0
+# Dj4iYbNZ9jy430tJZEpTjBkhGomMWIDm4ujSChg9fvGw2c8SXGonGTLR85NYDCMbIyLEqzboKUumMK9h
+# jTaEXb05691A7wSnkJImbSLVYXmxuS8UbSs1jHWbpPddPbIDV42duuSooKGYoKgXrnGioaSFH4M3mwIn
+# 8o0Gnp5FJcb8tTfVEL5WyNs6ZQdCuMMHzglfzPYcWUuFr95Ne04CVgYZmzNEm9CijgteUzyQrOzs8iWi
+# aCqTQeAAIfhIFr8CvA0gsHGIXdIvqkbCRJCCu9DrClMNKbYKvkHGocF65eiybmjFSQRStXRZwjrVIiUf
+# qkeeSfIlv8mDBBhj41rAZAIIVM9YLOzROVgeWOPmJuLuO2Qmd6ajxpGa1L6rJqN4aWX5uInzj2qJL1YT
+# TJx9Gzs1OoSALEEzHpkhwmW7xI2Oht9e6JUaPBWKWmGqIqEYCMiOvhX9x1lxdm9EiVGYEgVHRsbASNwY
+# gr6lNBxvYYnEyP2ZNBPYFnwf7FWHj30IvI2LJpsu5UGk2af0YYOyDZ9BrNrXTy40pvqMlIuHHuhLgVFk
+# jSDiFO584e3UpjPmlecgAltFQfQLei8fGnnokNPahM1VYZIkTYDk4KXK3UVUNbivYP0SMzvVo7K69oFJ
+# --------------------------------------------------------------------------------
+
+```


### PR DESCRIPTION
Fixes #5743

Adds optional help text to data info entries and renders it as a tooltip on info-pane keys. Known stream, processor and retention fields get specific help text; other metadata fields get a generic description.

Compiled the affected modules with Java 25:
`./gradlew :stroom-core-shared:compileJava :stroom-core-client:compileJava :stroom-data:stroom-data-store-impl:compileJava`

Additional validation:
- Required changelog entry generated with `log_change.sh` (commit `ef923b4`).
- `:stroom-app-gwt:gwtDraftCompile`: passed.
- `:stroom-core-shared:test --tests stroom.data.shared.TestDataInfoSection`: three tests passed, covering legacy entries, omission of absent help text and nested response round trips.
- Built and started the local application against an isolated MySQL database; the Chrome sign-in screen loads.

The signed-in Info-pane tooltip check is still outstanding. No successful end-to-end tooltip check is claimed.
