### PR TITLE
Use the user-tab owner when creating API keys

### DIFF
--- a/stroom-core-client/src/main/java/stroom/security/client/presenter/ApiKeysPresenter.java
+++ b/stroom-core-client/src/main/java/stroom/security/client/presenter/ApiKeysPresenter.java
@@ -141,11 +141,10 @@ public class ApiKeysPresenter
     }
 
     private void createNewKey() {
-        final boolean allowOwnerSelection = owner == null;
         editApiKeyPresenterProvider.get().showCreateDialog(
                 Mode.PRE_CREATE,
                 listPresenter::refresh,
-                allowOwnerSelection);
+                owner);
     }
 
     private void editSelectedKey() {

--- a/stroom-core-client/src/main/java/stroom/security/client/presenter/EditApiKeyPresenter.java
+++ b/stroom-core-client/src/main/java/stroom/security/client/presenter/EditApiKeyPresenter.java
@@ -88,9 +88,15 @@ public class EditApiKeyPresenter
         reset();
     }
 
+    /// Shows the API key dialog, optionally scoped to a particular owner.
+    ///
+    /// @param mode the dialog mode
+    /// @param onChangeHandler called after an API key changes
+    /// @param owner the fixed owner, or null to default to the current user and allow
+    ///              users with Manage Users permission to select another owner
     public void showCreateDialog(final Mode mode,
                                  final Runnable onChangeHandler,
-                                 final boolean allowOwnerSelection) {
+                                 final UserRef owner) {
         GWT.log("showCreateDialog called");
         this.onChangeHandler = onChangeHandler;
         setMode(mode);
@@ -100,9 +106,11 @@ public class EditApiKeyPresenter
 
         if (Mode.PRE_CREATE.equals(mode)) {
             caption = "Create new API key";
-            // Default to current user
-            ownerPresenter.setSelected(securityContext.getUserRef());
-            ownerPresenter.setEnabled(allowOwnerSelection);
+            final boolean canManageUsers = securityContext.hasAppPermission(AppPermission.MANAGE_USERS_PERMISSION);
+            ownerPresenter.setSelected(owner != null && canManageUsers
+                    ? owner
+                    : securityContext.getUserRef());
+            ownerPresenter.setEnabled(owner == null && canManageUsers);
         } else if (Mode.POST_CREATE.equals(mode)) {
             caption = "View created API key";
         } else {

--- a/stroom-core-client/src/test/java/stroom/security/client/presenter/TestEditApiKeyPresenter.java
+++ b/stroom-core-client/src/test/java/stroom/security/client/presenter/TestEditApiKeyPresenter.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stroom.security.client.presenter;
+
+import stroom.dispatch.client.RestFactory;
+import stroom.security.client.api.ClientSecurityContext;
+import stroom.security.client.presenter.EditApiKeyPresenter.EditApiKeyView;
+import stroom.security.client.presenter.EditApiKeyPresenter.Mode;
+import stroom.security.shared.AppPermission;
+import stroom.ui.config.client.UiConfigCache;
+import stroom.util.shared.UserRef;
+
+import com.google.gwt.core.client.GWT;
+import com.google.web.bindery.event.shared.EventBus;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TestEditApiKeyPresenter {
+
+    private static final UserRef CURRENT_USER = UserRef.forUserUuid("current-user");
+    private static final UserRef OTHER_USER = UserRef.forUserUuid("other-user");
+
+    @Test
+    void testOwnerSelectionRequiresManageUsersPermission() {
+        assertOwnerSelection(false, null, CURRENT_USER, false);
+    }
+
+    @Test
+    void testScopedDialogUsesSpecifiedOwner() {
+        assertOwnerSelection(true, OTHER_USER, OTHER_USER, false);
+    }
+
+    @Test
+    void testUnscopedDialogDefaultsToCurrentUser() {
+        assertOwnerSelection(true, null, CURRENT_USER, true);
+    }
+
+    @Test
+    void testScopedDialogCannotBypassManageUsersPermission() {
+        assertOwnerSelection(false, OTHER_USER, CURRENT_USER, false);
+    }
+
+    @Test
+    void testOwnUserTabKeepsOwnerFixed() {
+        assertOwnerSelection(true, CURRENT_USER, CURRENT_USER, false);
+    }
+
+    private void assertOwnerSelection(final boolean canManageUsers,
+                                     final UserRef scopedOwner,
+                                     final UserRef expectedOwner,
+                                     final boolean expectedEnabled) {
+        try (final MockedStatic<GWT> ignored = mockStatic(GWT.class)) {
+            final ClientSecurityContext securityContext = mock(ClientSecurityContext.class);
+            when(securityContext.getUserRef()).thenReturn(CURRENT_USER);
+            when(securityContext.hasAppPermission(AppPermission.MANAGE_USERS_PERMISSION))
+                    .thenReturn(canManageUsers);
+            final UserRefSelectionBoxPresenter ownerPresenter = mock(UserRefSelectionBoxPresenter.class);
+            final EditApiKeyPresenter presenter = new EditApiKeyPresenter(
+                    mock(EventBus.class),
+                    mock(EditApiKeyView.class),
+                    mock(RestFactory.class),
+                    securityContext,
+                    mock(UiConfigCache.class),
+                    ownerPresenter);
+
+            presenter.showCreateDialog(Mode.PRE_CREATE, () -> {}, scopedOwner);
+
+            final ArgumentCaptor<Boolean> enabled = ArgumentCaptor.forClass(Boolean.class);
+            verify(ownerPresenter, atLeastOnce()).setEnabled(enabled.capture());
+            assertThat(enabled.getValue()).isEqualTo(expectedEnabled);
+            verify(ownerPresenter).setSelected(expectedOwner);
+        }
+    }
+}

--- a/unreleased_changes/20260910_155712_071__5659.md
+++ b/unreleased_changes/20260910_155712_071__5659.md
@@ -1,0 +1,68 @@
+* Bug **#5659** : Use the selected user as the owner when creating an API key from their user tab. Preserve Manage Users permission checks when enabling owner selection.
+
+
+```sh
+# ********************************************************************************
+# Issue number: 5659
+# Issue title:  API Keys sub-tab on User screen does not let you create a key for another user.
+# Issue tags:   f:ui / ux
+# Issue link:   https://github.com/gchq/stroom/issues/5659
+# ********************************************************************************
+
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Bug **#123** : Fix bug with an associated GitHub issue in this repository.
+#
+# * Bug **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository.
+#
+# * Feature **#789** : Add new feature X.
+#
+# * Bug : Fix bug with no associated GitHub issue.
+#
+#
+# Note: The line must start '* XXX ', where 'XXX' is a valid category,
+#       one of [Bug Feature Refactor Dependency Build].
+
+
+# --------------------------------------------------------------------------------
+# The following is random text to make this file unique for git's change detection
+# eifumxCBlqN8jgxYQvPbdQjwbBTOBgtCMysSzJNtmKtNpJWUXVJfLof6cTnVnlsXTojwg08ke2UXScmI
+# phMuMazIQaCTbe0w44GK2LNs82LZ91muiA0nqdBsYQYQ9kXhnVqZDTmFdngVhpTrjqn0DhoRTCoWUqm4
+# 2rcwnnslcAVtfbsRLK9bsJLdJqE7DOvS6e7ZfHjNITy6aEkkGGJ9qOOo74hy6tFZRSWdmbax7OLohkBO
+# SHt8IXc6TIelhfuWkfgYMaj56EhCFIKEJGtudNSnLfNvYEnltPGk94cipEl32dwkiPx9WsCUmYp4jKxo
+# Yl7ZTNgYfxpO8VvSd3Y3mdDNaihpUDEy9HyYouoXQHVuOtQgncSPPJ15y5q32K6TlWdiViU4Or4oTuBR
+# GgBzSGIBF1Uuyc2EiemI3JWtnzdEz5WwYGXHqmJjf4FMLs9sAyMPbAx3ypCKlKDfpOarCz6yHB7S226b
+# Be6Q328444XzLgGStxXy55EjQ4rURmqY5fzqY0oWpgBQB1PMjatOxiZ0jNwjaT3PPk6niQm7xzCEM1Kp
+# LXGlAD0gmE61FEU9YP2KpPo3ran4GBPmCmNl093zujvGlyY7uAvFLrJQCFeaGslgrcRhmtqlxhSdp6WY
+# cnRvikhEADckBQoHPSJ5aHiskNoNAZfLbBaVMuEbMa18cLncVIDCMolwe821HlTSWS63HXTWYAf4K4Dd
+# YR4vZqRK1FoqpNXiHRvxR1dzcO4s2Km8cWgDZqWeXnKWg6o1D4lJt336B2LpAPbRBqP6ROdZB9dqgHKI
+# EjfEGBqKfhIk3Kngyr16tDgXiUFLjwkAjtj5JC66v2ohUm2B81f3mppGM1Ay0shMEoKQdgOB6N2DSh8p
+# OfmUaWidEBfmCl5T2FCEozFxOISgDdisl5iRYgUlcNy2UDe9lnHfH4BsWig0LsayLFwP7DfIdfmzZXuJ
+# d7bbNBh00lJC7tk0qPIBrb1sLx2I6Jyey0AsiR0ouJRhcqX0FY5CscW8ylws9EXEVkE16KR3xxXnVmYK
+# Wzx4vG6BUPaepqqxTqlml7vfKZlnfPwtIKmXxbCODbr8Cf9DAZi2DM5N8uealraKoEyeVr6UXaEPOwe4
+# Eb89qFjruAshudBx5rdzA3g4NfS1WTDmL5o75vibTd5OcOsx9lHN0fULbU8bj7lHDG1MSQyKsrRSx6ia
+# 91bEmJ63VOW6GuAiK6ek6iHyhlbxQJdEDcGIDYQGZvXEGvtRcWaLHQiqHHsBTuMswwNHFg07U1UskboZ
+# 9Rg7JRDM6eYsqZavpsUl2y86dbwa01MxRX4aFIzWfx12OmbFbpHCwgsegSLHtUhN4mmi4TnWlE2Rrpxn
+# aALymIobbShGAA4U76Zy8VOEy0Jth5xc0Rxx30DwjX4naojvCTo2d9kNtaV37J03WO6GFLUZp9YcIxB4
+# Dat8DNxV8FjCKHJq2tncyU7wkzAcZv0lvaXxMKoXr53SyLQeJ4neXmHhGJtiWMs4giYkGTTwwW1cmhXW
+# 8KnmCd5x2TUd4sJNgTMchycG7L3Ti3J0TqbMLG6w7jkX9qu13iWEmy3pFO3drVjZPA2btERZvpRUa0r0
+# YDEI3NMJTOOpzXDnSdQXiY03Fev8aX599aYCa7l9QUDAdOtAUP0IlZQDrxK0hwTeWPkNA6j297kweYfR
+# NM7XVWejO26txq6ruA2PwvORGhTeAtd4Ciqjem5ZiZIfCQ7tVL5QiMCBjy1i4CjVOKXHwOu7WCa1Eysp
+# apqx0bdWAnAdyZ9DOWhlWfQXfac55eVl7xKoO0ihIqk8pAZkEG2QHsl7ocHM0nMMhpXO5SKycnFjRKjr
+# jx9thydlNsAK3le3YpXZcQG3ai08DuAr7OTUF6vMzsg8waQlpc84hsBiv1rOnrwbssd6XFgH8zAHtGM2
+# KlOj1ify0zsYsV4M6TqpZP1E8tRrs655Yq8BC4EmCzJd0GYVH0R64zIy6sUVps7SiY0okLHpehSon0PH
+# 7gTSs4uqQ0BvK3Fene1KSIms4mccspRgQypzQ7pNpKYU4pgh31buxzRsw8bK5InhAjtl0md6vNyCTxCA
+# JRDwEc5SxJo0KWfPqGl1rZSgkMhUFXfqzY56gTI3bkah57vO29vkvB4ecRosVpriOEzJBXdEx8vVwau9
+# YAl5Gz72C0rjotDTe7V1okmmfXTRX0nAazHnNDCMAetXmuhf7lUzTy4ezUYvnWi5XRdcNxNPIfQN2rV3
+# u1V55J0B3jVCRkEPbPMXLPIEPNe5huBEsRgso6gaYWcTAR1kRn7PsCaadgFjUgkAELUq5W5pooRHN6AA
+# j9x1KPE9DLDqF244lL9p3bjhJXyhXsMWXk2i2mjWNGV3F20GdshBE7OSZgA7LoBgRLhA8otOMjnkzk3r
+# --------------------------------------------------------------------------------
+
+```

--- a/unreleased_changes/20260910_160000_000__5659.md
+++ b/unreleased_changes/20260910_160000_000__5659.md
@@ -1,1 +1,0 @@
-* Bug **#5659** : Use the selected user as the owner when creating an API key from their user tab. Preserve Manage Users permission checks when enabling owner selection.

--- a/unreleased_changes/20260910_160000_000__5659.md
+++ b/unreleased_changes/20260910_160000_000__5659.md
@@ -1,0 +1,1 @@
+* Bug **#5659** : Use the selected user as the owner when creating an API key from their user tab. Preserve Manage Users permission checks when enabling owner selection.


### PR DESCRIPTION
Fixes #5659.

Pass the user-tab owner into the API key creation dialog. Scoped dialogs keep that owner fixed; the main API Keys screen still defaults to the current user. Owner selection remains restricted to users with Manage Users permission, including when a different scoped owner is supplied.

Adds five presenter regressions and a release note.

## Validation

- Core client suite: 143 passed, 2 skipped.
- Main and test Checkstyle checks passed.
- The permission regression fails on the original code. Restoring the original owner selection also makes the scoped-owner regression fail.

Run with Temurin 25:
```
./gradlew :stroom-core-client:test :stroom-core-client:checkstyleMain :stroom-core-client:checkstyleTest
```

The full monorepo build and browser end-to-end tests were not run. Existing Gradle and JVM warnings also occur on the unchanged baseline.
