### PR TITLE
Remove redundant work queues from scheduled execution

### DIFF
--- a/stroom-analytics/stroom-analytics-impl/src/main/java/stroom/analytics/impl/ScheduledExecutorService.java
+++ b/stroom-analytics/stroom-analytics-impl/src/main/java/stroom/analytics/impl/ScheduledExecutorService.java
@@ -26,12 +26,10 @@ import stroom.docstore.api.DocFinder;
 import stroom.node.api.NodeInfo;
 import stroom.security.api.SecurityContext;
 import stroom.security.shared.AppPermission;
-import stroom.task.api.ExecutorProvider;
 import stroom.task.api.TaskContext;
 import stroom.task.api.TaskContextFactory;
 import stroom.task.api.TaskTerminatedException;
 import stroom.util.concurrent.UncheckedInterruptedException;
-import stroom.util.concurrent.WorkQueue;
 import stroom.util.date.DateUtil;
 import stroom.util.logging.LambdaLogger;
 import stroom.util.logging.LambdaLoggerFactory;
@@ -74,9 +72,8 @@ import java.util.function.Supplier;
  * </p>
  *
  * <p>
- *     Execution is performed asynchronously using a {@link stroom.task.api.ExecutorProvider}
- *     but constrained to a single-threaded execution per document and per schedule to ensure
- *     deterministic behaviour.
+ *     Documents and their schedules execute sequentially on the calling thread. Callers that
+ *     require asynchronous execution are responsible for submitting this service to an executor.
  * </p>
  *
  * <p>
@@ -92,7 +89,6 @@ public final class ScheduledExecutorService<T> implements HasUserDependencies {
     private static final LambdaLogger LOGGER = LambdaLoggerFactory.getLogger(ScheduledExecutorService.class);
 
     private final ExecutionScheduleDao executionScheduleDao;
-    private final ExecutorProvider executorProvider;
     private final TaskContextFactory taskContextFactory;
     private final NodeInfo nodeInfo;
     private final SecurityContext securityContext;
@@ -101,7 +97,6 @@ public final class ScheduledExecutorService<T> implements HasUserDependencies {
     /**
      * Creates a new scheduled executor service.
      *
-     * @param executorProvider     Provider for executor services.
      * @param taskContextFactory   Factory for creating task contexts.
      * @param nodeInfo             Information about the current node.
      * @param securityContext      Security context used for permission checks and run-as execution.
@@ -109,13 +104,11 @@ public final class ScheduledExecutorService<T> implements HasUserDependencies {
      * @param docFinderProvider    Provider for document reference decoration.
      */
     @Inject
-    ScheduledExecutorService(final ExecutorProvider executorProvider,
-                             final TaskContextFactory taskContextFactory,
+    ScheduledExecutorService(final TaskContextFactory taskContextFactory,
                              final NodeInfo nodeInfo,
                              final SecurityContext securityContext,
                              final ExecutionScheduleDao executionScheduleDao,
                              final Provider<DocFinder> docFinderProvider) {
-        this.executorProvider = executorProvider;
         this.taskContextFactory = taskContextFactory;
         this.nodeInfo = nodeInfo;
         this.securityContext = securityContext;
@@ -154,14 +147,13 @@ public final class ScheduledExecutorService<T> implements HasUserDependencies {
 
             info(() -> "Processing " + LogUtil.namedCount("scheduled " + scheduledExecutable.getProcessType(),
                     NullSafe.size(docs)));
-            final WorkQueue workQueue = new WorkQueue(executorProvider.get(), 1, 1);
             for (final T doc : docs) {
                 if (Thread.currentThread().isInterrupted()) {
                     throw new UncheckedInterruptedException(new InterruptedException());
                 }
                 final Runnable runnable = createRunnable(doc, taskContext, scheduledExecutable);
                 try {
-                    workQueue.exec(runnable);
+                    runnable.run();
                 } catch (final TaskTerminatedException | UncheckedInterruptedException e) {
                     LOGGER.debug(e::getMessage, e);
                     throw e;
@@ -169,9 +161,6 @@ public final class ScheduledExecutorService<T> implements HasUserDependencies {
                     LOGGER.error(e::getMessage, e);
                 }
             }
-
-            // Join.
-            workQueue.join();
 
             scheduledExecutable.postExecuteTidyUp(docs);
 
@@ -360,15 +349,13 @@ public final class ScheduledExecutorService<T> implements HasUserDependencies {
             return executionScheduleDao.fetchExecutionSchedule(request);
         });
 
-        final WorkQueue workQueue = new WorkQueue(executorProvider.get(), 1, 1);
         for (final ExecutionSchedule executionSchedule : executionSchedules.getValues()) {
             if (Thread.currentThread().isInterrupted()) {
                 throw new UncheckedInterruptedException(new InterruptedException());
             }
             final Runnable runnable = () -> {
                 try {
-                    // We need to set the user again here as it will have been lost from the parent context as we are
-                    // running within a new thread.
+                    // Each schedule must run as its configured user, independently of the caller.
                     LOGGER.debug(() -> LogUtil.message("DocRef: {}, running as user: {}",
                             docRef.toShortString(), executionSchedule.getRunAsUser()));
 
@@ -388,9 +375,8 @@ public final class ScheduledExecutorService<T> implements HasUserDependencies {
                                     scheduledExecutable.getIdentity(doc)), e);
                 }
             };
-            workQueue.exec(runnable);
+            runnable.run();
         }
-        workQueue.join();
     }
 
     /**
@@ -434,10 +420,12 @@ public final class ScheduledExecutorService<T> implements HasUserDependencies {
                         scheduledExecutable)).get();
     }
 
+    /// Executes a schedule immediately on the calling thread using its configured run-as user.
+    ///
+    /// @param executionSchedule the schedule to execute
+    /// @param scheduledExecutable the executable implementation
     public void executeNow(final ExecutionSchedule executionSchedule,
                            final ScheduledExecutable<T> scheduledExecutable) {
-        // TODO Why is this using the workQueue, only one task is ever executed
-        final WorkQueue workQueue = new WorkQueue(executorProvider.get(), 1, 1);
         final Runnable runnable = () -> {
             try {
                 securityContext.asUser(executionSchedule.getRunAsUser(), () -> securityContext.useAsRead(() -> {
@@ -453,8 +441,7 @@ public final class ScheduledExecutorService<T> implements HasUserDependencies {
                                 scheduledExecutable.getProcessType()), e);
             }
         };
-        workQueue.exec(runnable);
-        workQueue.join();
+        runnable.run();
     }
 
     /**

--- a/stroom-analytics/stroom-analytics-impl/src/test/java/stroom/analytics/impl/TestScheduledExecutorService.java
+++ b/stroom-analytics/stroom-analytics-impl/src/test/java/stroom/analytics/impl/TestScheduledExecutorService.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stroom.analytics.impl;
+
+import stroom.analytics.impl.ScheduledExecutorService.ExecutionResult;
+import stroom.analytics.shared.ExecutionHistory;
+import stroom.analytics.shared.ExecutionSchedule;
+import stroom.analytics.shared.ExecutionScheduleRequest;
+import stroom.docref.DocRef;
+import stroom.docstore.api.DocFinder;
+import stroom.node.api.NodeInfo;
+import stroom.security.api.SecurityContext;
+import stroom.task.api.ExecutorProvider;
+import stroom.task.api.TaskContext;
+import stroom.task.api.TaskContextFactory;
+import stroom.util.shared.ResultPage;
+import stroom.util.shared.UserRef;
+import stroom.util.shared.scheduler.Schedule;
+import stroom.util.shared.scheduler.ScheduleType;
+
+import com.google.inject.Guice;
+import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TestScheduledExecutorService {
+
+    private final ExecutionScheduleDao dao = mock(ExecutionScheduleDao.class);
+    private final ExecutorProvider executorProvider = mock(ExecutorProvider.class);
+    private final TaskContextFactory taskContextFactory = mock(TaskContextFactory.class);
+    private final TaskContext taskContext = mock(TaskContext.class);
+    private final SecurityContext securityContext = mock(SecurityContext.class);
+    private final NodeInfo nodeInfo = mock(NodeInfo.class);
+    private final DocFinder docFinder = mock(DocFinder.class);
+    @SuppressWarnings("unchecked")
+    private final ScheduledExecutable<DocRef> executable = mock(ScheduledExecutable.class, CALLS_REAL_METHODS);
+    private final Map<String, ExecutionSchedule> schedules = new LinkedHashMap<>();
+    private final List<String> executions = new ArrayList<>();
+    private final List<UserRef> users = new ArrayList<>();
+    private final List<Thread> threads = new ArrayList<>();
+    private final List<ExecutionHistory> history = new ArrayList<>();
+    private final UserRef caller = UserRef.forUserUuid("caller");
+    private final AtomicReference<UserRef> currentUser = new AtomicReference<>(caller);
+    private ScheduledExecutorService<DocRef> service;
+
+    @BeforeEach
+    void setUp() {
+        when(executorProvider.get()).thenReturn(command -> {
+            throw new RejectedExecutionException("No spare pool threads");
+        });
+        when(nodeInfo.getThisNodeName()).thenReturn("node1");
+        when(taskContextFactory.current()).thenReturn(taskContext);
+        when(taskContextFactory.<Boolean>childContextResult(any(), anyString(), any()))
+                .thenAnswer(invocation -> (Supplier<Boolean>) () -> invocation
+                        .<Function<TaskContext, Boolean>>getArgument(2)
+                        .apply(taskContext));
+        when(taskContextFactory.<Boolean>contextResult(anyString(), any()))
+                .thenAnswer(invocation -> (Supplier<Boolean>) () -> invocation
+                        .<Function<TaskContext, Boolean>>getArgument(1)
+                        .apply(taskContext));
+        when(securityContext.asProcessingUserResult(any())).thenAnswer(invocation -> invocation
+                .<Supplier<?>>getArgument(0)
+                .get());
+        doAnswer(invocation -> {
+            final UserRef previous = currentUser.getAndSet(invocation.getArgument(0));
+            try {
+                invocation.<Runnable>getArgument(1).run();
+            } finally {
+                currentUser.set(previous);
+            }
+            return null;
+        }).when(securityContext).asUser(any(UserRef.class), any(Runnable.class));
+        doAnswer(invocation -> {
+            invocation.<Runnable>getArgument(0).run();
+            return null;
+        }).when(securityContext).useAsRead(any());
+        when(dao.fetchScheduleByUuid(anyString())).thenAnswer(invocation ->
+                Optional.ofNullable(schedules.get(invocation.<String>getArgument(0))));
+        when(dao.fetchExecutionSchedule(any())).thenAnswer(invocation -> {
+            final ExecutionScheduleRequest request = invocation.getArgument(0);
+            return ResultPage.createUnboundedList(schedules.values().stream()
+                    .filter(schedule -> schedule.getOwningDoc().equals(request.getOwnerDocRef()))
+                    .toList());
+        });
+        when(dao.updateExecutionSchedule(any())).thenAnswer(invocation -> {
+            final ExecutionSchedule schedule = invocation.getArgument(0);
+            schedules.put(schedule.getUuid(), schedule);
+            return schedule;
+        });
+        doAnswer(invocation -> {
+            history.add(invocation.getArgument(0));
+            return null;
+        }).when(dao).addExecutionHistory(any());
+        when(executable.getProcessType()).thenReturn("test");
+        when(executable.getDocRef(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(executable.getIdentity(any())).thenAnswer(invocation -> invocation
+                .<DocRef>getArgument(0)
+                .getName());
+        when(executable.load(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(executable.reload(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(executable.run(any(), any(), any(), any(), any(), any(), any())).thenAnswer(invocation -> {
+            final ExecutionSchedule schedule = invocation.getArgument(4);
+            executions.add(schedule.getUuid());
+            users.add(currentUser.get());
+            threads.add(Thread.currentThread());
+            return new ExecutionResult("Complete", null);
+        });
+        service = Guice.createInjector(binder -> {
+            binder.bind(ExecutionScheduleDao.class).toInstance(dao);
+            binder.bind(ExecutorProvider.class).toInstance(executorProvider);
+            binder.bind(TaskContextFactory.class).toInstance(taskContextFactory);
+            binder.bind(SecurityContext.class).toInstance(securityContext);
+            binder.bind(NodeInfo.class).toInstance(nodeInfo);
+            binder.bind(DocFinder.class).toInstance(docFinder);
+        }).getInstance(Key.get(new TypeLiteral<ScheduledExecutorService<DocRef>>() {}));
+    }
+
+    @Test
+    void executesDocumentsAndSchedulesWithoutSparePoolThreads() {
+        final DocRef first = new DocRef("Test", "first", "First");
+        final DocRef second = new DocRef("Test", "second", "Second");
+        final ExecutionSchedule firstSchedule = addSchedule("one", first);
+        final ExecutionSchedule secondSchedule = addSchedule("two", first);
+        final ExecutionSchedule thirdSchedule = addSchedule("three", second);
+        when(executable.getDocs()).thenReturn(List.of(first, second));
+
+        service.exec(executable);
+
+        assertThat(executions).containsExactly("one", "two", "three");
+        assertThat(users).containsExactly(firstSchedule.getRunAsUser(), secondSchedule.getRunAsUser(),
+                thirdSchedule.getRunAsUser());
+        assertThat(threads).containsOnly(Thread.currentThread());
+        assertThat(currentUser.get()).isEqualTo(caller);
+        assertThat(history).hasSize(3);
+        verify(executable).postExecuteTidyUp(List.of(first, second));
+    }
+
+    @Test
+    void executesNowWithoutSparePoolThreads() {
+        final ExecutionSchedule schedule = addSchedule("now", new DocRef("Test", "one", "One"));
+
+        service.executeNow(schedule, executable);
+
+        assertThat(executions).containsExactly("now");
+        assertThat(threads).containsOnly(Thread.currentThread());
+        assertThat(users).containsExactly(schedule.getRunAsUser());
+        assertThat(currentUser.get()).isEqualTo(caller);
+        assertThat(history).hasSize(1);
+    }
+
+    @Test
+    void continuesAfterFailureLoadingOneDocument() {
+        final DocRef first = new DocRef("Test", "first", "First");
+        final DocRef second = new DocRef("Test", "second", "Second");
+        addSchedule("failed", first);
+        addSchedule("working", second);
+        when(executable.getDocs()).thenReturn(List.of(first, second));
+        when(executable.reload(first)).thenThrow(new IllegalStateException("Document unavailable"));
+
+        service.exec(executable);
+
+        assertThat(executions).containsExactly("working");
+        assertThat(currentUser.get()).isEqualTo(caller);
+        verify(executable).postExecuteTidyUp(List.of(first, second));
+    }
+
+    @Test
+    void doesNotExecuteTerminatedParent() {
+        final DocRef doc = new DocRef("Test", "one", "One");
+        addSchedule("one", doc);
+        when(executable.getDocs()).thenReturn(List.of(doc));
+        when(taskContext.isTerminated()).thenReturn(true);
+
+        service.exec(executable);
+
+        assertThat(executions).isEmpty();
+        assertThat(history).isEmpty();
+    }
+
+    @Test
+    void doesNotExecuteInterruptedCaller() {
+        final DocRef doc = new DocRef("Test", "one", "One");
+        addSchedule("one", doc);
+        when(executable.getDocs()).thenReturn(List.of(doc));
+        try {
+            Thread.currentThread().interrupt();
+            service.exec(executable);
+            assertThat(executions).isEmpty();
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    private ExecutionSchedule addSchedule(final String id, final DocRef doc) {
+        final ExecutionSchedule schedule = ExecutionSchedule.builder()
+                .uuid(id)
+                .name(id)
+                .enabled(true)
+                .nodeName("node1")
+                .schedule(Schedule.builder().type(ScheduleType.INSTANT).build())
+                .owningDoc(doc)
+                .runAsUser(UserRef.forUserUuid(id + "-user"))
+                .build();
+        schedules.put(id, schedule);
+        return schedule;
+    }
+}

--- a/unreleased_changes/20260910_160008_288__5667.md
+++ b/unreleased_changes/20260910_160008_288__5667.md
@@ -1,0 +1,68 @@
+* Bug **#5667** : Remove redundant single-threaded work queues from scheduled execution.
+
+
+```sh
+# ********************************************************************************
+# Issue number: 5667
+# Issue title:  `ScheduledExecutorService` is incorrectly using WorkQueue
+# Issue tags:   HPE, refactor
+# Issue link:   https://github.com/gchq/stroom/issues/5667
+# ********************************************************************************
+
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Bug **#123** : Fix bug with an associated GitHub issue in this repository.
+#
+# * Bug **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository.
+#
+# * Feature **#789** : Add new feature X.
+#
+# * Bug : Fix bug with no associated GitHub issue.
+#
+#
+# Note: The line must start '* XXX ', where 'XXX' is a valid category,
+#       one of [Bug Feature Refactor Dependency Build].
+
+
+# --------------------------------------------------------------------------------
+# The following is random text to make this file unique for git's change detection
+# mIRg420ZWR6UCt01VZo1rM5K64iRPQEyrTno12X0iIIbVWHc0K2viwy6Cx4kSdkBwkXV7F4oA1CYcf4E
+# 4sCeias0xz5JWxxb3PlDJhJCIlQwVHXfvMxxMD4HFRkEkyBLmTnLimLBLDuFpzuGX78wxPvWT5XI5VDa
+# f0NALLcBtuNS6MgunODCHz3Bx2sVqYwSIDroTnT37FUmmeXKTF99R6fxOLpTP6dLZ8Br97T0Qp9rgtYN
+# fSeQC5vz8a6hpgQ6DGw9anTKBs3J6hvM2bDeNDNatHFCz80VPHtZb3x1JUAChQe3RANG3euRkV9Wn0HJ
+# mrfv7a3OIkgF313DPfjvpUW9iOya85llww8xg12vmDWe90MzWdkmhg19FN7l40Ny2HoIjnHbijGwUAL9
+# 5baIfj8Od4C1raMRm1cXOb3t0ixxjAjysbuECQ0Vf8TByOGDftuM3m19Ce3Hy2RrjZIS6aZCB3lQqsFo
+# 6qcBjzUhalFZO6udHlzl2hv4fzY0OvOvf2I6oCKsxVzKOPqh7n1WR0gqG7UGfj7g15U3GasoNS7i6h7z
+# uXjo53r23SSs9JpEdVC5PTlB4uPP9GvjdkVfKi7NOFogt5FLFaPyT1XrVipNowIUnJ1bmcf8jhaFcXmB
+# uec5sEJwC2s8oPX1J4vnz0bcMvdyifqtLkhWAbDDh4yXcmnIpn49KStTgSsJqWP1yqwYnCnxWLKNFcrp
+# dj0xbJKWX0UNUTgpABDULMsLNBpvS9qIvOQa6Lj6Z1G2xNO3LkefQV5RwYqOgd3QeBKWs4BxJAp23ivH
+# 0JPdzT40uiBjhLpR3WdVVYHfGinry3UxfvCXv5bXhfJvKU71t5UpphNSe6NfubLXXBCGbp17vUOxmP2B
+# G7L9LYbccNhGS3O7b4FQWJZF7xg2ERIxqGMnGTV1t5hRsKjaHM3pU7BoUEZ3uNwHfgVdJ1LB9sX8ltTX
+# fPdAcBZsxZuUszPqYHJstP4JH9rWaHmsV4kzxcNBKW9NtzPSDL5avLTjUYmjKbH14r1VXQMFzeLT4fvQ
+# 2XLiPjiVLizp1AV9d3HAxzRVMJqIg5KWwZ6LfAzSe5iboqwhNKX4jnHCgA6taIlZ8tP1aYvpaEoPT9sN
+# TPfsXqkzkJeREMpIXIvDtZ1cu0fVS1kUb8QQl68DN98aM1UoSeLFtNA2WCCLNaEfNxamCmG1fy3tjmV8
+# KVlSarjtpK6h1Y3x8frzu5IMLyO6a4DfPNGl25j7mFAfxI5l2t8lQv8CZr6bIJpUIq2fGizIsxKzPruK
+# DFo6ynJPsagGOPIH7egnszXBV2Js8D2EuBIcLUmuThyKBELzrqbzC4OXJ8hysmXjYHe3HDeviaS49o9K
+# i6Bcjl4i2ZW3NQdfgpwtoPjt1rapTQQbcowQqPi2BIqgdhmJXkUuPt3XnTrCKtRVDhTFlCW6wCrKjUu7
+# umHYzzRSpxQckg2l5jr7mfxSRjaRo3NIECiw7dicoQXRGFoPUZ4hFXv0RKRGvEKE1BHnlWbm1rMii5rJ
+# Z7MzhdgeUVCQ6Hw1s4SKMk7ncNUkX1gQeL78b7v3AMzD612AzRbVSBT1hsF6L7QbwIWYi5YEP2YjKBWR
+# DrumdxuyJP9dCbmE5l09VNpTEoLg5JPVlQ5lc3kP6PHEnEP8VXLll1qSvRNQow6e88lDIlibfAnFDpSe
+# zmVNX7aYbkYpLN3KnbnmgcFjQA4I4JxxTPerVAuLs6Nk6hAfZ9RYr7g57dPgefCJAQOCNS0JSwUig7a8
+# gSR9ZLobU546dQAn7mMiO4Dl6BWAjQyYjRE7l1V8Bh9oylwzGqlsNF3L4k5LBwV80As9IHkoXJgu3EoZ
+# 3md90bJiKt8LgTtFh64zjzBENJqfmtfoQ09ERcTNQWbUjgg7E7etg8ibEWh4VeLmCoVSfZZTPMEanwrr
+# IphdjUWpW7JhVeSeBnTbjaQcLhVoy1csfambLQvMS1nH4anJiYLpMtr0MwRpKYfu26GGdHW0GTtEnz23
+# PfeqvVNzi7QezJRXygHJYIxQLsVDjk3GziYdu0djfe8hYTGKttWL66XzTOq1vGEBGlqH5GIVrFK14BKF
+# 8bJGPAHV6xhnGwBtoqvyV9tiiL3ZgwA0XO13QkTFzMAd8yfKXsf1P6XGxJARH5nfWzwZWS4jws2fUSVY
+# wNTaGKB0YEnk0J1LmWJr1VU2Gl8Qmbj9SevUCRrB6lTBhR54puaIhzCxwDdvByWtOemrymQC6oqtW5xz
+# SMpw1PpsdXVlPW94ZRRakB4sajctwtal08Lc98i2dDKObnfMX5zWoHKNDPwbXPD61tVlehoALc76LktD
+# AoDjyaJDoaDXIaZEMOpUwoGhlsIU5tjA2xG7XArJPpV5VCoTleaKdJOn411aIuNUJLLGEWtvRuVYxL63
+# --------------------------------------------------------------------------------
+
+```


### PR DESCRIPTION
Fixes #5667.

Run documents and their schedules sequentially on the calling thread instead of creating nested, single-threaded work queues. Keep the run-as user, read context, task context, failure handling and post-execution cleanup. Remove the unused executor dependency.

Validation:
- Analytics module tests: 58 passed, one skipped, including five new regression tests.
- Three new tests fail on the original implementation because it requires spare pool threads.
- Main and test Checkstyle checks passed on current master with Java 25.
- Changelog entry generated with `log_change.sh`.

The full application test suite was not run.
