### PR TITLE
Refresh document permission details after edits

### DIFF
--- a/stroom-core-client/build.gradle
+++ b/stroom-core-client/build.gradle
@@ -35,5 +35,6 @@ dependencies {
     testImplementation libs.slf4j.api
 
     testImplementation libs.bundles.common.test.implementation
+    testRuntimeOnly libs.javax.inject.gwt
     testRuntimeOnly libs.bundles.common.test.runtime
 }

--- a/stroom-core-client/src/main/java/stroom/security/client/presenter/DocumentUserPermissionsEditPresenter.java
+++ b/stroom-core-client/src/main/java/stroom/security/client/presenter/DocumentUserPermissionsEditPresenter.java
@@ -66,6 +66,7 @@ public class DocumentUserPermissionsEditPresenter
 
     private UserRef relatedUser;
     private DocRef relatedDoc;
+    private Runnable onPermissionsChanged = () -> {};
 
     @Inject
     public DocumentUserPermissionsEditPresenter(final EventBus eventBus,
@@ -89,6 +90,7 @@ public class DocumentUserPermissionsEditPresenter
                      final TaskMonitorFactory taskMonitorFactory) {
         relatedDoc = docRef;
         relatedUser = permissions.getUserRef();
+        onPermissionsChanged = onClose;
 
         // Fetch detailed permissions report.
         docPermissionClient.getDocUserPermissionsReport(relatedDoc, relatedUser, response ->
@@ -151,8 +153,8 @@ public class DocumentUserPermissionsEditPresenter
 
     @Override
     public void onEditCreatePermissions(final TaskMonitorFactory taskMonitorFactory) {
-        documentUserCreatePermissionsEditPresenterProvider.get().show(relatedDoc, relatedUser, () -> {
-        }, taskMonitorFactory);
+        documentUserCreatePermissionsEditPresenterProvider.get().show(
+                relatedDoc, relatedUser, onPermissionsChanged, taskMonitorFactory);
     }
 
     @Override

--- a/stroom-core-client/src/main/java/stroom/security/client/presenter/DocumentUserPermissionsPresenter.java
+++ b/stroom-core-client/src/main/java/stroom/security/client/presenter/DocumentUserPermissionsPresenter.java
@@ -59,6 +59,7 @@ public class DocumentUserPermissionsPresenter
     private final ButtonView docEdit;
     private final SelectionBox<PermissionShowLevel> permissionVisibility;
     private DocRef docRef;
+    private int detailsRequestId;
 
     @Inject
     public DocumentUserPermissionsPresenter(
@@ -113,11 +114,12 @@ public class DocumentUserPermissionsPresenter
                 documentUserPermissionsListPresenter.getSelectionModel().getSelected();
         if (selected != null) {
             documentUserPermissionsEditPresenterProvider.get().show(
-                    docRef, selected, documentUserPermissionsListPresenter::refresh, this);
+                    docRef, selected, this::refresh, this);
         }
     }
 
     public void setDocRef(final DocRef docRef) {
+        detailsRequestId++;
         this.docRef = docRef;
         documentUserPermissionsListPresenter.setDocRef(docRef);
         documentUserPermissionsListPresenter.refresh();
@@ -149,13 +151,23 @@ public class DocumentUserPermissionsPresenter
 //                .fire();
 //    }
 
+    private void refresh() {
+        documentUserPermissionsListPresenter.refresh();
+        updateDetails();
+    }
+
     private void updateDetails() {
+        final int requestId = ++detailsRequestId;
+        final DocRef requestedDocRef = docRef;
         final DocumentUserPermissions selection = documentUserPermissionsListPresenter
                 .getSelectionModel()
                 .getSelected();
         // Fetch detailed permissions report.
         if (selection != null) {
-            docPermissionClient.getDocUserPermissionsReport(docRef, selection.getUserRef(), response -> {
+            docPermissionClient.getDocUserPermissionsReport(requestedDocRef, selection.getUserRef(), response -> {
+                if (requestId != detailsRequestId || !Objects.equals(requestedDocRef, docRef)) {
+                    return;
+                }
                 final SafeHtml details = getDetails(response);
                 getView().setUserRef(selection.getUserRef());
                 getView().setDetails(details);

--- a/stroom-core-client/src/test/java/stroom/security/client/presenter/TestDocumentUserPermissionsEditPresenter.java
+++ b/stroom-core-client/src/test/java/stroom/security/client/presenter/TestDocumentUserPermissionsEditPresenter.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stroom.security.client.presenter;
+
+import stroom.docref.DocRef;
+import stroom.security.client.presenter.DocumentUserPermissionsEditPresenter.DocumentUserPermissionsEditView;
+import stroom.security.shared.DocumentPermission;
+import stroom.security.shared.DocumentUserPermissions;
+import stroom.util.shared.UserRef;
+
+import com.google.gwt.core.client.GWT;
+import com.google.web.bindery.event.shared.EventBus;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+
+class TestDocumentUserPermissionsEditPresenter {
+
+    @Test
+    void testCreatePermissionChangesNotifyParent() {
+        try (final MockedStatic<GWT> ignored = mockStatic(GWT.class)) {
+            final DocRef document = new DocRef("Folder", "document", "Folder");
+            final UserRef user = UserRef.forUserUuid("user");
+            final DocumentUserCreatePermissionsEditPresenter createEditor =
+                    mock(DocumentUserCreatePermissionsEditPresenter.class);
+            final DocumentUserPermissionsEditPresenter editor = new DocumentUserPermissionsEditPresenter(
+                    mock(EventBus.class), mock(DocumentUserPermissionsEditView.class),
+                    mock(DocPermissionRestClient.class), mock(ExplorerClient.class),
+                    mock(PermissionChangeClient.class), () -> createEditor);
+            final Runnable onChange = mock(Runnable.class);
+            editor.show(document, new DocumentUserPermissions(user, DocumentPermission.USE, Set.of()),
+                    onChange, editor);
+
+            editor.onEditCreatePermissions(editor);
+            final ArgumentCaptor<Runnable> callback = ArgumentCaptor.forClass(Runnable.class);
+            verify(createEditor).show(eq(document), eq(user), callback.capture(), eq(editor));
+            callback.getValue().run();
+
+            verify(onChange).run();
+        }
+    }
+}

--- a/stroom-core-client/src/test/java/stroom/security/client/presenter/TestDocumentUserPermissionsPresenter.java
+++ b/stroom-core-client/src/test/java/stroom/security/client/presenter/TestDocumentUserPermissionsPresenter.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stroom.security.client.presenter;
+
+import stroom.docref.DocRef;
+import stroom.item.client.SelectionBox;
+import stroom.security.client.presenter.DocumentUserPermissionsPresenter.DocumentUserPermissionsView;
+import stroom.security.shared.DocumentPermission;
+import stroom.security.shared.DocumentUserPermissions;
+import stroom.security.shared.DocumentUserPermissionsReport;
+import stroom.security.shared.PermissionShowLevel;
+import stroom.svg.client.Preset;
+import stroom.util.shared.UserRef;
+import stroom.widget.button.client.ButtonView;
+import stroom.widget.util.client.MultiSelectEvent;
+import stroom.widget.util.client.MultiSelectionModel;
+import stroom.widget.util.client.SafeHtmlUtil;
+import stroom.widget.util.client.SelectionType;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.web.bindery.event.shared.EventBus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TestDocumentUserPermissionsPresenter {
+
+    private static final DocRef DOCUMENT = new DocRef("Folder", "document", "Folder");
+    private static final UserRef FIRST_USER = UserRef.forUserUuid("first");
+    private static final UserRef SECOND_USER = UserRef.forUserUuid("second");
+
+    private MockedStatic<GWT> gwt;
+    private MockedStatic<SafeHtmlUtil> html;
+    private DocPermissionRestClient client;
+    private DocumentUserPermissionsView view;
+    private DocumentUserPermissionsListPresenter list;
+    private DocumentUserPermissionsEditPresenter editor;
+    private MultiSelectionModel<DocumentUserPermissions> selection;
+    private MultiSelectEvent.Handler handler;
+    private DocumentUserPermissionsPresenter presenter;
+    private final List<Consumer<DocumentUserPermissionsReport>> responses = new ArrayList<>();
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        gwt = mockStatic(GWT.class);
+        html = mockStatic(SafeHtmlUtil.class, CALLS_REAL_METHODS);
+        final SafeHtmlUtil.Template template = mock(SafeHtmlUtil.Template.class);
+        html.when(SafeHtmlUtil::getTemplate).thenReturn(template);
+        when(template.spanWithClass(anyString(), any())).thenAnswer(invocation -> invocation.getArgument(1));
+        client = mock(DocPermissionRestClient.class);
+        view = mock(DocumentUserPermissionsView.class);
+        list = mock(DocumentUserPermissionsListPresenter.class);
+        editor = mock(DocumentUserPermissionsEditPresenter.class);
+        selection = mock(MultiSelectionModel.class);
+        final SelectionBox<PermissionShowLevel> visibility = mock(SelectionBox.class);
+        when(view.getPermissionVisibility()).thenReturn(visibility);
+        when(list.getSelectionModel()).thenReturn(selection);
+        when(list.addButton(any(Preset.class))).thenReturn(mock(ButtonView.class));
+        doAnswer(invocation -> {
+            responses.add(invocation.getArgument(2));
+            return null;
+        }).when(client).getDocUserPermissionsReport(any(), any(), any(), any());
+        presenter = new DocumentUserPermissionsPresenter(
+                mock(EventBus.class), client, view, list, () -> editor);
+        presenter.onBind();
+        final ArgumentCaptor<MultiSelectEvent.Handler> captor = ArgumentCaptor.forClass(MultiSelectEvent.Handler.class);
+        verify(selection).addSelectionHandler(captor.capture());
+        handler = captor.getValue();
+        presenter.setDocRef(DOCUMENT);
+        clearInvocations(view, list);
+    }
+
+    @AfterEach
+    void tearDown() {
+        html.close();
+        gwt.close();
+    }
+
+    @Test
+    void testEditRefreshesListAndDetails() {
+        select(FIRST_USER, true);
+        final ArgumentCaptor<Runnable> onChange = ArgumentCaptor.forClass(Runnable.class);
+        verify(editor).show(eq(DOCUMENT), any(), onChange.capture(), eq(presenter));
+
+        onChange.getValue().run();
+
+        verify(list).refresh();
+        verify(client, times(2)).getDocUserPermissionsReport(eq(DOCUMENT), eq(FIRST_USER), any(), eq(presenter));
+    }
+
+    @Test
+    void testEditDiscardsOlderReportForSameUser() {
+        select(FIRST_USER, true);
+        final ArgumentCaptor<Runnable> onChange = ArgumentCaptor.forClass(Runnable.class);
+        verify(editor).show(eq(DOCUMENT), any(), onChange.capture(), eq(presenter));
+        onChange.getValue().run();
+        responses.get(1).accept(report(DocumentPermission.OWNER));
+        responses.get(0).accept(report(DocumentPermission.USE));
+
+        final ArgumentCaptor<SafeHtml> details = ArgumentCaptor.forClass(SafeHtml.class);
+        verify(view).setDetails(details.capture());
+        assertThat(details.getValue().asString()).contains("OWNER");
+    }
+
+    @Test
+    void testOlderSelectionResponseIsIgnored() {
+        select(FIRST_USER, false);
+        select(SECOND_USER, false);
+        responses.get(1).accept(report(DocumentPermission.OWNER));
+        responses.get(0).accept(report(DocumentPermission.USE));
+
+        verify(view, never()).setUserRef(FIRST_USER);
+        verify(view).setUserRef(SECOND_USER);
+        final ArgumentCaptor<SafeHtml> details = ArgumentCaptor.forClass(SafeHtml.class);
+        verify(view).setDetails(details.capture());
+        assertThat(details.getValue().asString()).contains("OWNER");
+    }
+
+    @Test
+    void testClearingSelectionDiscardsPendingResponse() {
+        select(FIRST_USER, false);
+        select(null, false);
+        responses.get(0).accept(report(DocumentPermission.OWNER));
+
+        verify(view, never()).setUserRef(FIRST_USER);
+        verify(view).setUserRef(null);
+    }
+
+    @Test
+    void testResponseForPreviousDocumentIsIgnored() {
+        select(FIRST_USER, false);
+        presenter.setDocRef(new DocRef("Folder", "other", "Other"));
+        clearInvocations(view);
+        responses.get(0).accept(report(DocumentPermission.OWNER));
+
+        verify(view, never()).setDetails(any());
+    }
+
+    @Test
+    void testReopeningDocumentDiscardsPendingReport() {
+        select(FIRST_USER, false);
+        presenter.setDocRef(new DocRef("Folder", "other", "Other"));
+        presenter.setDocRef(DOCUMENT);
+        responses.get(0).accept(report(DocumentPermission.OWNER));
+
+        verify(view, never()).setDetails(any());
+    }
+
+    private void select(final UserRef user, final boolean edit) {
+        when(selection.getSelected()).thenReturn(user == null
+                ? null
+                : new DocumentUserPermissions(user, DocumentPermission.USE, Set.of()));
+        final MultiSelectEvent event = mock(MultiSelectEvent.class);
+        final SelectionType type = mock(SelectionType.class);
+        when(event.getSelectionType()).thenReturn(type);
+        when(type.isDoubleSelect()).thenReturn(edit);
+        handler.onSelect(event);
+    }
+
+    private DocumentUserPermissionsReport report(final DocumentPermission permission) {
+        return new DocumentUserPermissionsReport(permission, Set.of(), null, null);
+    }
+}

--- a/unreleased_changes/20260910_180000_000__5537.md
+++ b/unreleased_changes/20260910_180000_000__5537.md
@@ -1,0 +1,1 @@
+* Bug **#5537** : Refresh document permission details after editing permissions, including nested create-permission edits. Ignore reports for an older selection or document.


### PR DESCRIPTION
Fixes #5537.

Refresh the list and details after permission edits. Forward nested create-permission changes to the parent view, and discard reports superseded by a newer request, cleared selection or changed document.

Adds seven presenter regressions and the existing javax.inject library to the test runtime for presenter mocks.

Validation: core-client suite has 145 passed and 2 skipped. Main/test Checkstyle passed under Temurin 25. Five regression tests fail against the original presenter code.

The full monorepo build and browser end-to-end tests were not run.
