### PR TITLE
Preserve downstream status in forwarding failure logs

### DIFF
--- a/stroom-proxy/stroom-proxy-app/src/main/java/stroom/proxy/app/handler/ForwardException.java
+++ b/stroom-proxy/stroom-proxy-app/src/main/java/stroom/proxy/app/handler/ForwardException.java
@@ -106,6 +106,13 @@ public class ForwardException extends RuntimeException {
         return feedName;
     }
 
+    /// Returns the downstream Stroom status associated with this forwarding failure.
+    ///
+    /// @return the Stroom status code
+    public StroomStatusCode getStroomStatusCode() {
+        return stroomStatusCode;
+    }
+
     public int getHttpResponseCode() {
         return httpResponseCode;
     }

--- a/stroom-proxy/stroom-proxy-app/src/main/java/stroom/proxy/app/handler/RetryingForwardDestination.java
+++ b/stroom-proxy/stroom-proxy-app/src/main/java/stroom/proxy/app/handler/RetryingForwardDestination.java
@@ -237,6 +237,7 @@ public class RetryingForwardDestination implements ForwardDestination {
         try {
             delegateDestination.add(sourceDir);
         } catch (final Exception e) {
+            addError(sourceDir, e);
             LOGGER.error(
                     "Error sending '" + FileUtil.getCanonicalPath(sourceDir)
                     + "' to " + getDestinationType() + " forward destination '"
@@ -500,6 +501,14 @@ public class RetryingForwardDestination implements ForwardDestination {
             if (e.getMessage() != null) {
                 sb.append(" - ");
                 sb.append(e.getMessage().replace('\n', ' '));
+            }
+            if (e instanceof final ForwardException forwardException) {
+                sb.append(" - Stroom status: ");
+                sb.append(forwardException.getStroomStatusCode().getCode());
+                sb.append(" - ");
+                sb.append(forwardException.getStroomStatusCode().getMessage());
+                sb.append(" - HTTP status: ");
+                sb.append(forwardException.getHttpResponseCode());
             }
             sb.append("\n");
             final Path errorPath = getErrorLogFile(dir);

--- a/stroom-proxy/stroom-proxy-app/src/test/java/stroom/proxy/app/handler/TestRetryingForwardDestination.java
+++ b/stroom-proxy/stroom-proxy-app/src/test/java/stroom/proxy/app/handler/TestRetryingForwardDestination.java
@@ -18,6 +18,8 @@ package stroom.proxy.app.handler;
 
 import stroom.meta.api.AttributeMap;
 import stroom.meta.api.AttributeMapUtil;
+import stroom.proxy.StroomStatusCode;
+import stroom.proxy.app.handler.HttpSender.ResponseStatus;
 import stroom.proxy.repo.ProxyServices;
 import stroom.proxy.repo.queue.QueueMonitors;
 import stroom.proxy.repo.store.FileStores;
@@ -36,18 +38,23 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -227,6 +234,91 @@ class TestRetryingForwardDestination {
         assertThat(callCount)
                 .hasValue(2);
         proxyServices.stop();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void test_errorLogIncludesStroomStatus(final boolean queueAndRetryEnabled) throws Exception {
+        final ForwardException exception = ForwardException.nonRecoverable(
+                new ResponseStatus(StroomStatusCode.FEED_IS_NOT_SET_TO_RECEIVE_DATA,
+                        null, "Not Acceptable", 406),
+                new AttributeMap());
+
+        final String errorLog = readFailureLog(exception, queueAndRetryEnabled);
+
+        assertThat(errorLog)
+                .contains(" - ForwardException - Not Acceptable")
+                .contains("Stroom status: 110 - Feed is not set to receive data")
+                .contains("HTTP status: 406");
+        assertThat(errorLog.lines().count())
+                .isEqualTo(1);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void test_errorLogPreservesUnknownStatusDetails(final boolean queueAndRetryEnabled) throws Exception {
+        final ForwardException exception = ForwardException.recoverable(
+                new ResponseStatus(StroomStatusCode.UNKNOWN_ERROR, null,
+                        "Downstream unavailable\nPlease try later", 503),
+                new AttributeMap());
+
+        final String errorLog = readFailureLog(exception, queueAndRetryEnabled);
+
+        assertThat(errorLog)
+                .contains("Downstream unavailable Please try later")
+                .contains("Stroom status: " + StroomStatusCode.UNKNOWN_ERROR.getCode())
+                .contains(StroomStatusCode.UNKNOWN_ERROR.getMessage())
+                .contains("HTTP status: 503");
+        assertThat(errorLog.lines().count())
+                .isEqualTo(1);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void test_errorLogPreservesOtherExceptions(final boolean queueAndRetryEnabled) throws Exception {
+        final String errorLog = readFailureLog(new IllegalStateException("Connection failed"), queueAndRetryEnabled);
+
+        assertThat(errorLog)
+                .endsWith(" - IllegalStateException - Connection failed\n")
+                .doesNotContain("Stroom status", "HTTP status");
+    }
+
+    private String readFailureLog(final Exception exception,
+                                  final boolean queueAndRetryEnabled) throws Exception {
+        final ForwardHttpQueueConfig config = ForwardHttpQueueConfig.builder()
+                .forwardDelay(queueAndRetryEnabled)
+                .maxRetryAge(StroomDuration.ZERO)
+                .build();
+        final RetryingForwardDestination destination = new RetryingForwardDestination(
+                config, mockDelegateDestination, this::getDataDir,
+                new SimplePathCreator(() -> homeDir, () -> tempDir),
+                dirQueueFactory, proxyServices, mockFileStores);
+        Mockito.doThrow(exception)
+                .when(mockDelegateDestination)
+                .add(Mockito.any());
+        proxyServices.start();
+        try {
+            destination.add(createSourceDir(1));
+            TestUtil.waitForIt(
+                    () -> findErrorLogs(destination.getFailureDir()).size(),
+                    1,
+                    () -> "failure error.log to be written",
+                    Duration.ofSeconds(5),
+                    Duration.ofMillis(20),
+                    Duration.ofSeconds(1));
+            return Files.readString(findErrorLogs(destination.getFailureDir()).getFirst());
+        } finally {
+            proxyServices.stop();
+        }
+    }
+
+    private List<Path> findErrorLogs(final Path failureDir) {
+        try (final Stream<Path> paths = Files.walk(failureDir)) {
+            return paths.filter(path -> path.getFileName().toString().equals("error.log"))
+                    .toList();
+        } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     private Path getDataDir() {

--- a/unreleased_changes/20260910_185210_398__5336.md
+++ b/unreleased_changes/20260910_185210_398__5336.md
@@ -1,0 +1,68 @@
+* Bug **#5336** : Include downstream Stroom and HTTP status details in forwarding failure logs.
+
+
+```sh
+# ********************************************************************************
+# Issue number: 5336
+# Issue title:  proxy not recording full error details in `error.log` file in the `_failure` dir
+# Issue tags:   f:proxy
+# Issue link:   https://github.com/gchq/stroom/issues/5336
+# ********************************************************************************
+
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Bug **#123** : Fix bug with an associated GitHub issue in this repository.
+#
+# * Bug **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository.
+#
+# * Feature **#789** : Add new feature X.
+#
+# * Bug : Fix bug with no associated GitHub issue.
+#
+#
+# Note: The line must start '* XXX ', where 'XXX' is a valid category,
+#       one of [Bug Feature Refactor Dependency Build].
+
+
+# --------------------------------------------------------------------------------
+# The following is random text to make this file unique for git's change detection
+# MaunY014Ud2lVE8OWQCp9lCMDjzUqEPFkZKDh44b7B1mabFtgwLChQXcoVZHbMKURbKHefWctMaqC7dN
+# m7z4r5M5Acat1f8ULor4YWb4aOLXvlMURLpbONJ6uAxu4JKUk7tYJimkENu94ecUKwbti8rhmZLKsGKk
+# QUNIwaSdueE4hbLVJUX3LRdhtfL8IpiBmynKf1xHBHwuwenI4bLajlUSL009vCU001BSuSggq39XKqRm
+# muugt4XtF5QKgXt6zUBai9R6EllPBkbbU69Kr2vfX6cJuTyT3GxycTlEYjtZY3P1imZrnUllr2yhpMIj
+# wr980HyNZTyhXrgOAPH71ixd11lp9qUJmPdDgo9tchfGHbLQxcrdujjr5pY2UdqI8aV9iVMybpsnoF5S
+# 54gzhqp4SArB8H1I4UCPbDr7hv4WulO6qrM9G5ptEjnQHKzIS8k8lN7RAEfJBbMgEGhYyEmEEBspSQCo
+# qPS7qfMsYr7nKmlCvSqa1OMQNvatklTYpcuePPSvTvqMhlHgGAZOZPuistd2rDxXSzNneFe1bquLMd5C
+# 8Z2PTo3yeBZulkXRzBvzK8KWCMyJwrzz7YlnEpqd5vPTqA4Cx8KLfZcgZerdedwbPDWgfgFHT7IDL5uR
+# 1yDsLHivCYyH8teuORFeWY1KqDSGURt5qp24geDO4kHu9VuBi7PulhqgoygFUBNW6prvm1Jfz6iTCV26
+# mn8puv3qfVFZ3nEUCfDVzfaAFXMIiS3EEGfuNI3viGh4b0uWwBQbrfkmTmsN0GBCSjOBEm41Tl4KubMU
+# eks4HaguJlDVh8oVa6Dt5NLANaYkNpyWgA6vdPVfvC981um6p3rCWjupJ4SXucjIEX81ZyfhfpjnfKBv
+# 7J9T86ioJaNfPql2vGP4XXk99KYPbtwav79LQEk5mv3NgjbdISVRsEPERk7IVXFtszZJAJ3vqrAZtGV1
+# 6fFpunK7HjjmW2VJc6zfvRhyaLe1Fqrxmmc2RT1rOEotImTTXVY8yKTroCGhRiAidlG4RQTNAVUttvs8
+# qJgY1cE1wzDjiohBKwG2sffkomBC4rNJB5BweCXkNY9eCC4PK3MgjzGvenzy7b7wb2tg424hYV67wonB
+# 7lLi5PqrKprqwULEJmF3qGrg5MJDNKckLBNLna4btRgLCDNLouwVnJJpWV10hmFQAEHC6ABwfyt0uuZz
+# K30Rnk5s6AOj1bgKXjUXuiVSKOTgBRzWitwQsr0cLT5vphJIUyUuhDWR537XZgHaT4QYvuGQ0g1xzlfc
+# e0Tixcd5WndTfvNXbN7P5blBIqsy0Z0Uj7af7Rt5kUi53TXryMIa7JclwFg4OOLBcVoyorYPlyp2IleD
+# KwVW7KlrVI7bi3lSk9jfJ7LQ1Nvd81XAFD83rowKA5fKf8vvLQU0oCQR7wlBD3oAgUT3LXOk5P76RZMu
+# 3ILSOypOrr5vuaJlHsIrN6aBupe8co5okaWm9vfZkb1rdQgjA5yU6tyLTOle0eIoHqniYeC6CNAmWvSR
+# Bj12ZVoOaVLk3sI8udFXWq7XR4vSpfH9xxf4NiA6YwbZX088REz3OIKsHiQRvRWAHJ3sxxR6yO8fcPfP
+# xxaHXmn0g0gFUigGscNltONovgYBg0gX5xmYiRI5ppA0jEB6VqcCSEVlR3feWKdm9pY2Sra83Ymv089J
+# 4hDOoOoo8SXySde9fRdicZAKcLF2DCbMgXWGS9GB7YwMjUr3T4bgfafNewfqciDBDWs43qh7TMDwNjoo
+# 37xmQ39PgdGSnGckgR1Vnr9MSMOa6VGI61YWixD6vvypWYQgeeFIFsaQr9QjwwhQ74jJ3lvNdoxuwiJv
+# W4ZXiSRjQI9gX8iyt2vIKbVEbwHOMqYk2vPqQQQnbLXq3glnLXTsjVAjTndLpUSaYUeffVvq9jOiqrbM
+# C96SZyEiEWPb0NCRAaeL3oCOSO3FnKHqqD2hoScscnYNbU4PPkcazAcLd94bOOmmETuAUZerzCGgdB4i
+# uknjoqRIFfsuseLCNXp9g5Eucga9dZgnXwA0LUjNRpcEO0cfgOfjU3TMdZEgMu2VFAYp1q2Ckx8ESFRa
+# Gcw3fOr4ec6d7ev3k8izlGMxu3aLHmF65Tj6z7GGhECAdSGIrrYgDUT2KKRAaFLUEV2BzDim6wfAEwGk
+# AB1vYLMkx2ZL2xC4Np9kQrNuk6gUJai5jhCSCCSuJX9poH4g8fuFyiN7lOcuP7FxJxmWMBl1QT3JANsS
+# ppWm44dlSjo3UpkBPvhksdZ5uIVgrFHWpUwlbEJC1hsWzeHH4vnjRqmumC4xTgEtwFJQ2jURd8AUZ0GW
+# okZ7VsdTTziZwPWUGQfG7wtddHAKDS13qaDXWJRO0oXIJSr3QKU18ZsB7c02r5PjlYBg8Tx42s6QnwVm
+# --------------------------------------------------------------------------------
+
+```


### PR DESCRIPTION
Fixes #5336.

Include the downstream Stroom status code and message, plus the actual HTTP status, in `error.log`. Write the same failure log when queuing and retries are disabled. Existing exception details and retry decisions are preserved.

Validation:
- Proxy handler suite: 242 passed, 3 skipped.
- Six new cases cover queued/direct failures, unknown status responses and ordinary exceptions. Five fail before the fix.
- Main and test Checkstyle checks passed with Java 25.
- Changelog entry generated with `log_change.sh`.
