### PR TITLE
Declare English as the application page language

### DIFF
--- a/stroom-app/src/main/resources/ui/TestSuperDevMode.html
+++ b/stroom-app/src/main/resources/ui/TestSuperDevMode.html
@@ -20,7 +20,7 @@
 <!-- "Standards Mode". Replacing this declaration   -->
 <!-- with a "Quirks Mode" doctype is not supported. -->
 
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 

--- a/stroom-app/src/main/resources/ui/index.html
+++ b/stroom-app/src/main/resources/ui/index.html
@@ -15,7 +15,7 @@
   -->
 
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title></title>
     <meta http-equiv="refresh" content="0; url=/" />

--- a/stroom-app/src/main/resources/ui/markdown-preview.html
+++ b/stroom-app/src/main/resources/ui/markdown-preview.html
@@ -17,7 +17,7 @@
 
 <!DOCTYPE html>
 
-<html>
+<html lang="en">
 <head>
     <link rel="stylesheet" href="css/app.css" type="text/css"/>
 <!--    <script type="text/javascript" src='markdown-preview.js'></script>-->

--- a/stroom-app/src/main/resources/ui/vis.html
+++ b/stroom-app/src/main/resources/ui/vis.html
@@ -17,7 +17,7 @@
 
 <!DOCTYPE html>
 
-<html>
+<html lang="en">
 <head>
 
 <link rel="stylesheet" href="css/vis.css" type="text/css" />

--- a/stroom-core/src/main/resources/stroom/core/servlet/app.html
+++ b/stroom-core/src/main/resources/stroom/core/servlet/app.html
@@ -17,7 +17,7 @@
 
 <!DOCTYPE html>
 
-<html class="@ROOT_CLASS@">
+<html lang="en" class="@ROOT_CLASS@">
   <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <title>@TITLE@</title>

--- a/stroom-core/src/test/java/stroom/core/servlet/TestAppServlet.java
+++ b/stroom-core/src/test/java/stroom/core/servlet/TestAppServlet.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stroom.core.servlet;
+
+import stroom.ui.config.shared.UiConfig;
+import stroom.ui.config.shared.UserPreferences;
+import stroom.ui.config.shared.UserPreferencesService;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TestAppServlet {
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testLanguageInRenderedPage(final boolean bootstrap) throws IOException {
+        final UserPreferencesService preferences = mock(UserPreferencesService.class);
+        when(preferences.fetchDefault()).thenReturn(UserPreferences.builder().build());
+        final AppServlet servlet = new AppServlet(UiConfig::new, () -> preferences) {
+            @Override
+            String getScript() {
+                return "ui/test/test.nocache.js";
+            }
+
+            @Override
+            boolean useBootstrap() {
+                return bootstrap;
+            }
+        };
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpServletResponse response = mock(HttpServletResponse.class);
+        final StringWriter output = new StringWriter();
+        when(response.getWriter()).thenReturn(new PrintWriter(output));
+
+        servlet.doGet(request, response);
+
+        assertThat(output.toString())
+                .containsPattern("<html\\s[^>]*lang=\"en\"")
+                .contains("ui/test/test.nocache.js")
+                .doesNotContain("@ROOT_CLASS@", "@BOOTSTRAP@");
+    }
+}

--- a/unreleased_changes/20260910_195825_242__5408.md
+++ b/unreleased_changes/20260910_195825_242__5408.md
@@ -1,0 +1,68 @@
+* Bug **#5408** : Declare English as the language of application pages for assistive technology.
+
+
+```sh
+# ********************************************************************************
+# Issue number: 5408
+# Issue title:  Language of page accessibility improvements
+# Issue tags:   accessibility, f:ui / ux
+# Issue link:   https://github.com/gchq/stroom/issues/5408
+# ********************************************************************************
+
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Bug **#123** : Fix bug with an associated GitHub issue in this repository.
+#
+# * Bug **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository.
+#
+# * Feature **#789** : Add new feature X.
+#
+# * Bug : Fix bug with no associated GitHub issue.
+#
+#
+# Note: The line must start '* XXX ', where 'XXX' is a valid category,
+#       one of [Bug Feature Refactor Dependency Build].
+
+
+# --------------------------------------------------------------------------------
+# The following is random text to make this file unique for git's change detection
+# mtsPbjxUo7QhGYjEyaV9R3cFXZg68vR2V5LYW7QJHbptrDpPB0CdpncuDOWq2MhsXULnaYMJFE0K5pfs
+# QZHXYKiocRpkQhNqlSClb9TJxfdSfpqXXjEbahNmrck0pwfYgvCtVg9P746aYmIHZz6dpycfQsJ6B5Js
+# vosc890VyiLCvN7uxHBi7ENeRwgBMRQARrfB96v5p1xCPJQKdZAFZr1kw9IEBXLpFjtXNf4kz8gJAfRw
+# pvzX0YsMiaGJkM0nQh4tDQQB87TX7cbsZ4OWpOjGbNHVLgLrK8sJFhocjVdwinq1TvLPAMh8Ys5I0x9l
+# t6hw3MZxVjSCO81BbdMx7GJ37fl4llwmeY7MBT3qvOuHKuGom3UPmZtR8J9eeRAjfnqljNS9yG0wAWfK
+# RxR6QTsJjgTfGFehGunoygowrktT0h6Plj3whJ9DkdbGyPsA2TbV7xI7T0uzbETjpSx6VP7OhXz1Yv0D
+# E9WRDIGOWlqpSl9uV4GF2CRKbCD9nhq9Zixx6VbeT8dN5LRcNPydmATsvgQvXPcqucNB6QqwYoSKnKzx
+# rgnJ2HZLBY1Uwi7wSoeYA2AYKzINowU9sGT2PiR7HEKLTDm5Om93GTrL2KubNgVB4Eosw7p8r3zXLsAg
+# 8L1IOCImuGmWTYMxVuqD2zPPEETcd8PmhEx5o09LuN8twmcQPJOxPZBNIYjdK5nEfXxmS3baAz8jaHKH
+# F9n8ktoVippMPypjULUQbafDegsGdnJDhs6G32BMuMCyqk15ECG5pEQj7iO1ztd8OWKIgOYcWWsv7Cyg
+# zvLnq5aQQFbmpaJ2RH26zf2xj4WE9oYGsmPXPJWY663mdj5S9eEneRDkWPzV23UksF2Uw73c8Qz9qDQQ
+# HcnLkKjQI3OaoD5Ufffg1gkm9c30FWrQIQ07Y5OAiFxCDypJdzKSvUoy1toxXHTbUXqgRtzH7WzyG5R8
+# eGiIKmpyHhv7vtkr7Tr2fj7ZE70gTvEt3BIun1o3HnQA5jMFCMuuUTpmixltcbNOCSoglkxCAm9DV7oI
+# jOyMV5FfzoCFIgLjBdVdKddjt1BEtF02qg1a0KsM6ME2g8eIxyhta0YGQahHXA3XJsEYraFcZcClXW8c
+# bJ6XP31N9drwj8WelEBIZ1TQpxrSeHfTg3Vkg9xwd4ML7CZstTkmcFnIcxJWpiOVP4BEP82me6TVlory
+# VKvZUSfIwQP3JZr2iMGLXlDtOx0isfTVDduCfEOwLAwUTlpRGDcZOOEpRzDQkWRLRMrdoLxyxOTeRCkp
+# 4uy0vCbRiE7VOQ61mi5DSR6kYD4E9G4BEHGgBR6ToBxCNMjdeiBEUnyKZOYE9Baekj8PW1l0F7OXZFFW
+# 3B2qeGT5o30sgJXfNarS93RZ5F1OlePfFcaXZTcsT7daU8VxiHZUYaLjHIeXsYIvi16s92rol0pgzrU6
+# Y2PRMw8qDdib7oskDOClwItq7Qqk5aR9U2RRcazx2LXF83cLZPgnXwMxfWo7YdrMsSo9c74KYs5LonJd
+# JYzrE53acJSFZdtfFLxEkg5GPnrJ4Y8VVvYzNcMsd6eEWFweyx7Pnoc8pGzzvh99b1bABflE3nPjtUH6
+# 6kRxCcbOLBXZgK76XzSlcdT3PWQCSYcek6nD3vki5dCIiZyGQB8CuEBaVKB2zc3bN1HUnnk3kgCw3HQg
+# ixIWP1t3aHAyK1y6K5kGC4KvtlOXBMKpXVkKPHA0kZEZpo25vi4EZCL75swE0LZnn3ZJnppnb7gHnuYi
+# Kz0HjZEbrNS8g4Tgg2973NxnNaMnh00bQrHJCVASG9DMOQPHP24czPnEx3XyuCwwbeBdHaUFdYbKCmTg
+# UKFqs6LnLnqc8Pk9VU4YQ0iarywoQlxGQwy6xocN3Jz646X5DxDg5lHLQJW8yThPywLu43NluEuAv81N
+# 88YOmNhKZusOlplpbqsd7zBZt9iaTPJxZxhLAclPN4wr0rvhpF9CvZrJ5HmeCtfQGhbTvrXv2p5uHMoO
+# mfVuJblXs9M6ecA11OiPyGRPu0ND51l643NhWWzhbNMLWvnjWQdnb2mb1PPGlxcy04ECDNAVy6kwgusj
+# OmoMxViuDAvzKLy1td0ptPDmVVcJQIiEk1SM8asppIkP6b2mG0zepZsdRjbXPUeXz0TCN27gPhcgMXvU
+# kUlaUpgSTCpwQKLJh6zndtLpAmk5QFhqJbUd6ZvHUaudZaRWEh7PdMqkx2nA7sK1UUOC4Vj0wjkzj8fN
+# cbRk7Qq19xHObiyHuo8K7LX03DsecICtIfsfGTqT2oyyhzen3JkHqB5Hz8l5b91rbRqiJ25zXapTHUP8
+# wklolarLMYNtnQsJyGO5J6XBR2PRSzlKdyKaVUsDV9M1UEyrzKY0zVYCIVaviZaFLznPBp84RqIYCtIM
+# --------------------------------------------------------------------------------
+
+```


### PR DESCRIPTION
Fixes #5408.

Declare `lang="en"` on the server-rendered application shell and the standalone UI pages. The shared shell covers both the authenticated application and the sign-in page; existing theme classes and scripts are unchanged.

Validation:
- All 13 `stroom-core` tests pass, including two new checks on the HTML actually rendered by `AppServlet`.
- Both new cases fail on the original template.
- Checkstyle passes for main and test sources.
- Parsed all five changed HTML resources and checked their single root element declares English.

Changelog generated with `log_change.sh`. No visual styling changes.
