### PR TITLE
Preserve interrupt status when wrapping interrupted operations

### DIFF
--- a/stroom-annotation/stroom-annotation-impl/src/main/java/stroom/annotation/impl/dao/AnnotationFeedDao.java
+++ b/stroom-annotation/stroom-annotation-impl/src/main/java/stroom/annotation/impl/dao/AnnotationFeedDao.java
@@ -129,7 +129,7 @@ class AnnotationFeedDao implements Clearable {
         try {
             return CompletableFuture.supplyAsync(supplier, executor).get();
         } catch (final InterruptedException e) {
-            throw new UncheckedInterruptedException(e);
+            throw UncheckedInterruptedException.create(e);
         } catch (final ExecutionException e) {
             if (e.getCause() instanceof RuntimeException) {
                 throw (RuntimeException) e.getCause();

--- a/stroom-annotation/stroom-annotation-impl/src/test/java/stroom/annotation/impl/dao/TestAnnotationFeedDaoInterruption.java
+++ b/stroom-annotation/stroom-annotation-impl/src/test/java/stroom/annotation/impl/dao/TestAnnotationFeedDaoInterruption.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stroom.annotation.impl.dao;
+
+import stroom.annotation.impl.db.AnnotationDbConnProvider;
+import stroom.task.api.ExecutorProvider;
+import stroom.util.concurrent.UncheckedInterruptedException;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TestAnnotationFeedDaoInterruption {
+
+    @Test
+    void testInterruptedWaitKeepsInterruptFlag() {
+        final List<Runnable> queued = new ArrayList<>();
+        final AnnotationFeedDao dao = createDao(queued::add);
+        try {
+            Thread.currentThread().interrupt();
+            assertThatThrownBy(() -> dao.async(() -> "result"))
+                    .isInstanceOf(UncheckedInterruptedException.class)
+                    .hasCauseInstanceOf(InterruptedException.class);
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+            assertThat(queued).hasSize(1);
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void testSuccessfulTaskDoesNotInterruptCaller() {
+        assertThat(createDao(Runnable::run).async(() -> "result")).isEqualTo("result");
+        assertThat(Thread.currentThread().isInterrupted()).isFalse();
+    }
+
+    @Test
+    void testFailedTaskPreservesCauseWithoutInterruptingCaller() {
+        final IllegalStateException failure = new IllegalStateException("Task failed");
+        assertThatThrownBy(() -> createDao(Runnable::run).async(() -> {
+            throw failure;
+        })).isSameAs(failure);
+        assertThat(Thread.currentThread().isInterrupted()).isFalse();
+    }
+
+    private AnnotationFeedDao createDao(final Executor executor) {
+        final ExecutorProvider provider = mock(ExecutorProvider.class);
+        when(provider.get()).thenReturn(executor);
+        return new AnnotationFeedDao(mock(AnnotationDbConnProvider.class), provider);
+    }
+}

--- a/stroom-lmdb/src/main/java/stroom/lmdb2/LmdbWriter.java
+++ b/stroom-lmdb/src/main/java/stroom/lmdb2/LmdbWriter.java
@@ -234,7 +234,7 @@ public class LmdbWriter {
                 }
             } catch (final InterruptedException e) {
                 LOGGER.error(e.getMessage(), e);
-                throw new UncheckedInterruptedException(e);
+                throw UncheckedInterruptedException.create(e);
             }
         } finally {
             // The write txn is closed by this point however we got here. Record that this

--- a/stroom-lmdb/src/test/java/stroom/lmdb2/TestLmdbWriter.java
+++ b/stroom-lmdb/src/test/java/stroom/lmdb2/TestLmdbWriter.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stroom.lmdb2;
+
+import stroom.util.concurrent.UncheckedInterruptedException;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TestLmdbWriter {
+
+    @Test
+    void testInterruptedTransferRestoresFlagAndClosesTransaction() {
+        final LmdbEnv env = mock(LmdbEnv.class);
+        final WriteTxn transaction = mock(WriteTxn.class);
+        when(env.writeTxn()).thenReturn(transaction);
+        final AtomicBoolean interruptedOnExit = new AtomicBoolean();
+        final Executor executor = command -> {
+            try {
+                Thread.currentThread().interrupt();
+                command.run();
+                interruptedOnExit.set(Thread.currentThread().isInterrupted());
+            } finally {
+                Thread.interrupted();
+            }
+        };
+
+        final LmdbWriter writer = new LmdbWriter(() -> executor, env);
+
+        assertThat(interruptedOnExit).isTrue();
+        verify(transaction).commit();
+        verify(transaction).close();
+        assertThatThrownBy(writer::close)
+                .hasCauseInstanceOf(UncheckedInterruptedException.class)
+                .hasRootCauseInstanceOf(InterruptedException.class);
+    }
+}

--- a/stroom-search/stroom-search-extraction/src/main/java/stroom/search/extraction/StreamEventMap.java
+++ b/stroom-search/stroom-search-extraction/src/main/java/stroom/search/extraction/StreamEventMap.java
@@ -76,7 +76,7 @@ public class StreamEventMap {
                 }
             } catch (final InterruptedException e) {
                 LOGGER.debug(e::getMessage, e);
-                throw new UncheckedInterruptedException(e);
+                throw UncheckedInterruptedException.create(e);
             }
         }
     }
@@ -104,7 +104,7 @@ public class StreamEventMap {
                 }
             } catch (final InterruptedException e) {
                 LOGGER.debug(e::getMessage, e);
-                throw new UncheckedInterruptedException(e);
+                throw UncheckedInterruptedException.create(e);
             }
         }
     }
@@ -152,7 +152,7 @@ public class StreamEventMap {
             }
         } catch (final InterruptedException e) {
             LOGGER.debug(e::getMessage, e);
-            throw new UncheckedInterruptedException(e);
+            throw UncheckedInterruptedException.create(e);
         }
     }
 
@@ -209,7 +209,7 @@ public class StreamEventMap {
             return eventSet;
         } catch (final InterruptedException e) {
             LOGGER.debug(e::getMessage, e);
-            throw new UncheckedInterruptedException(e);
+            throw UncheckedInterruptedException.create(e);
         }
     }
 

--- a/stroom-search/stroom-search-extraction/src/test/java/stroom/search/extraction/TestStreamEventMapInterruption.java
+++ b/stroom-search/stroom-search-extraction/src/test/java/stroom/search/extraction/TestStreamEventMapInterruption.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stroom.search.extraction;
+
+import stroom.util.concurrent.UncheckedInterruptedException;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TestStreamEventMapInterruption {
+
+    @Test
+    void testInterruptedPut() {
+        final StreamEventMap map = new StreamEventMap(1);
+        assertPreservesInterrupt(() -> map.put(new Event(1, 1, null)));
+        assertThat(map.size()).isZero();
+    }
+
+    @Test
+    void testInterruptedTake() {
+        final StreamEventMap map = new StreamEventMap(1);
+        assertPreservesInterrupt(map::take);
+    }
+
+    @Test
+    void testInterruptedComplete() {
+        final StreamEventMap map = new StreamEventMap(1);
+        assertPreservesInterrupt(map::complete);
+    }
+
+    @Test
+    void testInterruptedTerminate() {
+        final StreamEventMap map = new StreamEventMap(1);
+        assertPreservesInterrupt(map::terminate);
+    }
+
+    private void assertPreservesInterrupt(final ThrowingCallable operation) {
+        try {
+            Thread.currentThread().interrupt();
+            assertThatThrownBy(operation)
+                    .isInstanceOf(UncheckedInterruptedException.class)
+                    .hasCauseInstanceOf(InterruptedException.class);
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+        } finally {
+            Thread.interrupted();
+        }
+    }
+}

--- a/unreleased_changes/20260910_224000_000__5470.md
+++ b/unreleased_changes/20260910_224000_000__5470.md
@@ -1,0 +1,1 @@
+* Bug **#5470** : Preserve thread interruption when waiting for annotation feed lookups, extracting stream events and stopping the LMDB writer transfer loop.


### PR DESCRIPTION
Fixes #5470.

Restore the interrupt flag when annotation lookups, stream-event operations or the LMDB writer transfer loop wrap an InterruptedException. Retain the original cause and existing cleanup behaviour.

Other constructor calls already restore the flag, observe an already-interrupted thread, or explicitly avoid restoring it at a thread-pool boundary; those are unchanged.

Validation: 46 tests passed, 4 existing tests skipped, including 8 new regression/control tests. Six regressions failed on the original code. Checkstyle tasks passed with one existing file-length warning in unchanged AnnotationDaoImpl. Database-backed annotation and native LMDB integration suites were not run.
