### PR TITLE
Fix group membership actions on user tabs

### DIFF
--- a/stroom-core-client/src/main/java/stroom/security/client/presenter/UserAndGroupsPresenter.java
+++ b/stroom-core-client/src/main/java/stroom/security/client/presenter/UserAndGroupsPresenter.java
@@ -171,14 +171,14 @@ public class UserAndGroupsPresenter extends ContentTabPresenter<UserAndGroupsVie
 
         // Deal with Member Of Groups pane.
         registerHandler(parentsList.getSelectionModel().addSelectionHandler(e -> {
-            final User user = userList.getSelectionModel().getSelected();
+            final UserRef user = getSelectedUserRef();
             final User group = parentsList.getSelectionModel().getSelected();
             removeMemberOfButton.setEnabled(group != null && user != null);
         }));
 
         registerHandler(addMemberOfButton.addClickHandler(e -> {
             if (MouseUtil.isPrimary(e)) {
-                final User user = userList.getSelectionModel().getSelected();
+                final UserRef user = getSelectedUserRef();
                 if (user != null) {
                     final UserRefPopupPresenter userRefPopupPresenter = userRefPopupPresenterProvider.get();
                     userRefPopupPresenter.setAdditionalTerm(ExpressionTerm
@@ -190,7 +190,7 @@ public class UserAndGroupsPresenter extends ContentTabPresenter<UserAndGroupsVie
 
                     userRefPopupPresenter.show("Select Group", groupRef -> {
                         if (groupRef != null) {
-                            addUserToGroup(user.asRef(), groupRef, parentsList, groupRef);
+                            addUserToGroup(user, groupRef, parentsList, groupRef);
                         }
                     });
                 }
@@ -199,27 +199,27 @@ public class UserAndGroupsPresenter extends ContentTabPresenter<UserAndGroupsVie
 
         registerHandler(removeMemberOfButton.addClickHandler(e -> {
             if (MouseUtil.isPrimary(e)) {
-                final User user = userList.getSelectionModel().getSelected();
+                final UserRef user = getSelectedUserRef();
                 final User group = parentsList.getSelectionModel().getSelected();
-                removeUserFromGroup(user, group, parentsList);
+                removeUserFromGroup(user, NullSafe.get(group, User::asRef), parentsList);
             }
         }));
 
         // Deal with Members in Group pane.
         registerHandler(childrenList.getSelectionModel().addSelectionHandler(e -> {
-            final User group = userList.getSelectionModel().getSelected();
+            final UserRef group = getSelectedUserRef();
             final User user = childrenList.getSelectionModel().getSelected();
             removeMembersInButton.setEnabled(group != null && user != null);
         }));
 
         registerHandler(addMembersInButton.addClickHandler(e -> {
             if (MouseUtil.isPrimary(e)) {
-                final User group = userList.getSelectionModel().getSelected();
+                final UserRef group = getSelectedUserRef();
                 if (group != null) {
                     final UserRefPopupPresenter userRefPopupPresenter = userRefPopupPresenterProvider.get();
                     userRefPopupPresenter.show("Add User Or Group", userRef -> {
                         if (userRef != null) {
-                            addUserToGroup(userRef, group.asRef(), childrenList, userRef);
+                            addUserToGroup(userRef, group, childrenList, userRef);
                         }
                     });
                 }
@@ -228,9 +228,9 @@ public class UserAndGroupsPresenter extends ContentTabPresenter<UserAndGroupsVie
 
         registerHandler(removeMembersInButton.addClickHandler(e -> {
             if (MouseUtil.isPrimary(e)) {
-                final User group = userList.getSelectionModel().getSelected();
+                final UserRef group = getSelectedUserRef();
                 final User user = childrenList.getSelectionModel().getSelected();
-                removeUserFromGroup(user, group, childrenList);
+                removeUserFromGroup(NullSafe.get(user, User::asRef), group, childrenList);
             }
         }));
     }
@@ -304,9 +304,14 @@ public class UserAndGroupsPresenter extends ContentTabPresenter<UserAndGroupsVie
     }
 
     private void onSelection() {
-        final User selected = userList.getSelectionModel().getSelected();
-//        GWT.log("onSelection - selected: " + selected);
-        onSelection(NullSafe.get(selected, User::asRef));
+        onSelection(getSelectedUserRef());
+    }
+
+    private UserRef getSelectedUserRef() {
+        // The user-specific tab hides the top table, so it has no selected row.
+        return userRef != null
+                ? userRef
+                : NullSafe.get(userList.getSelectionModel().getSelected(), User::asRef);
     }
 
     private void onSelection(final UserRef selected) {
@@ -386,8 +391,8 @@ public class UserAndGroupsPresenter extends ContentTabPresenter<UserAndGroupsVie
         }
     }
 
-    private void removeUserFromGroup(final User user,
-                                     final User group,
+    private void removeUserFromGroup(final UserRef user,
+                                     final UserRef group,
                                      final UserListPresenter userListPresenter) {
         if (NullSafe.allNonNull(user, group)) {
             final User nextSelection = getNextSelection(userListPresenter);

--- a/stroom-core-client/src/test/java/stroom/security/client/presenter/TestUserAndGroupsPresenter.java
+++ b/stroom-core-client/src/test/java/stroom/security/client/presenter/TestUserAndGroupsPresenter.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stroom.security.client.presenter;
+
+import stroom.dispatch.client.RestFactory;
+import stroom.security.shared.User;
+import stroom.security.shared.UserResource;
+import stroom.ui.config.client.UiConfigCache;
+import stroom.util.shared.UserRef;
+import stroom.widget.button.client.ButtonView;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.NativeEvent;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.web.bindery.event.shared.SimpleEventBus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TestUserAndGroupsPresenter {
+
+    private MockedStatic<GWT> gwt;
+    private UserAndGroupsPresenter presenter;
+    private UserListPresenter users;
+    private UserListPresenter parents;
+    private UserListPresenter children;
+    private UserRefPopupPresenter popup;
+    private RestFactory restFactory;
+    private ButtonView addParent;
+    private ButtonView removeParent;
+    private ButtonView addChild;
+    private ButtonView removeChild;
+
+    @BeforeEach
+    void setUp() {
+        gwt = mockStatic(GWT.class);
+        gwt.when(() -> GWT.create(any())).thenAnswer(call -> mock((Class<?>) call.getArgument(0)));
+        users = mock(UserListPresenter.class, RETURNS_DEEP_STUBS);
+        parents = mock(UserListPresenter.class, RETURNS_DEEP_STUBS);
+        children = mock(UserListPresenter.class, RETURNS_DEEP_STUBS);
+        when(users.getSelectionModel().getSelected()).thenReturn(null);
+        when(parents.getSelectionModel().getSelected()).thenReturn(null);
+        when(children.getSelectionModel().getSelected()).thenReturn(null);
+        when(users.addButton(any())).thenAnswer(call -> mock(ButtonView.class));
+        addParent = mock(ButtonView.class);
+        removeParent = mock(ButtonView.class);
+        addChild = mock(ButtonView.class);
+        removeChild = mock(ButtonView.class);
+        when(parents.addButton(any())).thenReturn(addParent, removeParent);
+        when(children.addButton(any())).thenReturn(addChild, removeChild);
+        popup = mock(UserRefPopupPresenter.class);
+        restFactory = mock(RestFactory.class, RETURNS_DEEP_STUBS);
+        final List<UserListPresenter> lists = List.of(users, parents, children);
+        final AtomicInteger index = new AtomicInteger();
+        presenter = new UserAndGroupsPresenter(
+                new SimpleEventBus(),
+                mock(UserAndGroupsPresenter.UserAndGroupsView.class),
+                () -> lists.get(index.getAndIncrement()),
+                mock(CreateUserPresenter.class),
+                () -> mock(CreateNewGroupPresenter.class),
+                () -> popup,
+                mock(UiConfigCache.class),
+                restFactory);
+        presenter.onBind();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (gwt != null) {
+            gwt.close();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testAddParent(final boolean fixedUser) {
+        final User owner = selectOwner(fixedUser, false);
+        final User group = user("parent", true);
+        selectPopupResult(group.asRef());
+        click(addParent);
+        final UserResource resource = executeRequest();
+        verify(resource).addUserToGroup(owner.getUuid(), group.getUuid());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testAddChild(final boolean fixedUser) {
+        final User owner = selectOwner(fixedUser, true);
+        final User member = user("member", false);
+        selectPopupResult(member.asRef());
+        click(addChild);
+        final UserResource resource = executeRequest();
+        verify(resource).addUserToGroup(member.getUuid(), owner.getUuid());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testRemoveParent(final boolean fixedUser) {
+        final User owner = selectOwner(fixedUser, false);
+        final User group = user("parent", true);
+        when(parents.getSelectionModel().getSelected()).thenReturn(group);
+        click(removeParent);
+        final UserResource resource = executeRequest();
+        verify(resource).removeUserFromGroup(owner.getUuid(), group.getUuid());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testRemoveChild(final boolean fixedUser) {
+        final User owner = selectOwner(fixedUser, true);
+        final User member = user("member", false);
+        when(children.getSelectionModel().getSelected()).thenReturn(member);
+        click(removeChild);
+        final UserResource resource = executeRequest();
+        verify(resource).removeUserFromGroup(member.getUuid(), owner.getUuid());
+    }
+
+    @Test
+    void testRefreshKeepsFixedOwner() {
+        selectOwner(true, true);
+        clearInvocations(addParent, addChild);
+        presenter.refresh();
+        verify(addParent).setEnabled(true);
+        verify(addChild).setEnabled(true);
+    }
+
+    @Test
+    void testFixedOwnerOverridesHiddenTableSelection() {
+        final User owner = selectOwner(true, false);
+        when(users.getSelectionModel().getSelected()).thenReturn(user("stale", false));
+        final User group = user("parent", true);
+        selectPopupResult(group.asRef());
+        click(addParent);
+        verify(executeRequest()).addUserToGroup(owner.getUuid(), group.getUuid());
+    }
+
+    private User selectOwner(final boolean fixedUser, final boolean group) {
+        final User owner = user("owner", group);
+        if (fixedUser) {
+            presenter.setUserRef(owner.asRef());
+            assertThat(users.getSelectionModel().getSelected()).isNull();
+        } else {
+            when(users.getSelectionModel().getSelected()).thenReturn(owner);
+            presenter.refresh();
+        }
+        return owner;
+    }
+
+    private User user(final String id, final boolean group) {
+        return User.builder().uuid(id).subjectId(id).group(group).build();
+    }
+
+    private void selectPopupResult(final UserRef selected) {
+        doAnswer(call -> {
+            final Consumer<UserRef> consumer = call.getArgument(1);
+            consumer.accept(selected);
+            return null;
+        }).when(popup).show(anyString(), any());
+    }
+
+    private void click(final ButtonView button) {
+        final ArgumentCaptor<ClickHandler> handler = ArgumentCaptor.forClass(ClickHandler.class);
+        verify(button).addClickHandler(handler.capture());
+        final ClickEvent event = mock(ClickEvent.class);
+        when(event.getNativeButton()).thenReturn(NativeEvent.BUTTON_LEFT);
+        handler.getValue().onClick(event);
+    }
+
+    private UserResource executeRequest() {
+        final ArgumentCaptor<Function<UserResource, Boolean>> request = ArgumentCaptor.captor();
+        verify(restFactory.create(any(UserResource.class))).method(request.capture());
+        final UserResource resource = mock(UserResource.class);
+        request.getValue().apply(resource);
+        return resource;
+    }
+}

--- a/unreleased_changes/20260910_212836_173__5538.md
+++ b/unreleased_changes/20260910_212836_173__5538.md
@@ -1,0 +1,68 @@
+* Bug **#5538** : Use the user-tab owner for adding and removing group memberships.
+
+
+```sh
+# ********************************************************************************
+# Issue number: 5538
+# Issue title:  Add buttons on User/Group -> User Groups tab not working
+# Issue tags:   HPE, f:auth, f:ui / ux
+# Issue link:   https://github.com/gchq/stroom/issues/5538
+# ********************************************************************************
+
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Bug **#123** : Fix bug with an associated GitHub issue in this repository.
+#
+# * Bug **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository.
+#
+# * Feature **#789** : Add new feature X.
+#
+# * Bug : Fix bug with no associated GitHub issue.
+#
+#
+# Note: The line must start '* XXX ', where 'XXX' is a valid category,
+#       one of [Bug Feature Refactor Dependency Build].
+
+
+# --------------------------------------------------------------------------------
+# The following is random text to make this file unique for git's change detection
+# sIhG4n7KNXaPx8vdsnzTTb8FEOUd5FPrqfiq2XPeuddxgVdzpzs1vRluQ5TxHIJF8YyXV1yQWscJcWa4
+# hRmI4gaD9xpKjBziFGkYbfBhD4Ejqfpl6oTOeSwIhtL3qAsMvYjGy7qYOFgCpKHUyBqFNVNPbjfj2RqV
+# wc4ppEQpputQGUIy7EE3KQO4bEPI1qgSgXRX6Se5mqXLiT1suSfjQJjnbiHLntQGfu1htb9KXVQy8Fpf
+# f8HlWSG30ji3UGV6B9QnXdGzZtPqDikfsXv3IWk0AR66dveGOFyrVw9OV9FuhAP8hh5DWe78cw3VLfVa
+# 2waSIypCsnkxOrmtsgDuiVXti7eBaMHrOqtg8kjjkxS1sDbdYRaWz8ASIvrR0mJhUWlpf3qwC1jJiBin
+# sE2txpKl2NCOuAGbQMilSlkUk7cUlx6JIugGxpODlIY9KhM6Ypi3eAxAIMlt7Prk8vf6fPkTVb06jTwi
+# 9ITW1UfZK9Q18GLEFyUnuCpCzUd7kuz4DQW33dWBlGB0Eq3WQZpCMPlgNW0HnlvTikTugeG9jjcMesqb
+# M5VALDzqv3967Y9jVP4GqnisPyGUxQfw5Vjt3ABNla0w3nIA6TvcCaTBgGus3dprUORmGWvOAnH3zOft
+# hXbxI1Imh9p2U9BAEMdd2voSAtyOYdOKqLHrXuXmB46XH99MSFHsJw8hgrTTDtK78ymLNUJfYxYjEG4G
+# 2XOwX743Uqd1fWytT4e4LG1nfF0li0qw97kWaNMrJbU8pCVC8Eh17XACOpXma6fHE04JbI0llDF98uuK
+# UCRvj3W56J8bqsqFtVpyacSyHLPJWS9srlJ1DzM4QQCCmYmYsercQHO3HGPEf3Q80vzDrRsYrwondnAP
+# Nr3aecudPH1O1pmRr8Ynx6PALfdsyldVPLTtXfwtmcZck0UBJZ9ZtpyQrAxYpiXTnn95nq9ju3OIXHjV
+# B7ysc60h0e0Ixf1n6vXQbqQA4Lg5uKUL3ATzaSHbnsB1ai67aNDoib3UHHG9T8QO0HPjWGnvlIiAz03f
+# InxfPnztTQb4yJDgCY9pLKwGE3quFUuB8naNByMJvuWR1TDl4MSqExTwfVBqP2zKrXQYYbRME04FjwCV
+# QCtcoICZVktXs0d3wrS5gabxyDcgcmfnvgL5NwbVCd677Z6sk5dOrVwwLc5JcdHSLFt6YwfkofO4wrAS
+# NTi90zgwpSXRJOJf0kSinL5fT8V7VQGZhoPRTewkPB7lkbmIpRi3TOd5gSp7zd8Lit6zWUZqSsoj3IKb
+# 4LNPRlF05x519DdqmauikQKZL5kuXEWlzdcx7MmjgiOHDgHx25v4MmI5wDYm7JW6SONjuNT2ggwEYwpW
+# lFrmWtUqRtyEH6qZQJ23OkY0kQA0I3c5SG5GNMDKXLPD3vBZgzRUwBrYe3FICA8A48Lns0hmBomE7Gbh
+# y6wx272iqh1XH5RQwwbgeiAO8OoZc82mV7ez2KsEOGNlyZYfDIgKLWQbRE51YEJKjlqZ11JZ66CIERX5
+# aEUAMdc00Tvtk0HiBHFzbxGdEvw0gyWll5xbaJphmXTAG19lViQl8aQIBTAZorKMlDLA2z4SNxCBwSdU
+# cUXKxEzP3ntQLF4Pzr2B1IwpFq05Uyf2dzZapRM9ykl5Llrvj8nJJKJuyvDWz1zo6bZjDmNqrRgZKckV
+# pHMc1n8ogF3SEIG7anucwg4qfGbcUforz4C0426OzIAb7LJHoJMpHWHJupjzjQPkf7oNUsnjmu0Oq7JH
+# hhTfdgRLWP4m6qknFkMuWi9Q6ON6TghcwMnPpEM0JVYWTqgvQCGcXRtm2UMmyafao1oeGgxtbhFXLDuJ
+# mcxjkScJLHPB406hnYRMbK85ONFEOx9QHxG7ihWBFXu8IaBgTScLYwqiNyDmy49kYqW4aGRAUEocnPld
+# cEHwZw4nBP2MBTiPltAG0Cv4S2dWI4LzK0jMFyWOmf6JnxtE43XaGR8BcrI3u0JFbBughNzNG6RCnu0z
+# RUjppvK069Qn82m1Sk3o4hrlTDEUrYJoFr3FIgyJvCIhswSVM9lwzKvOKNuvtA2kw4BWm9hP5ZohWabC
+# hCDtfZgCf3tmIvvKBEQ1RYWV9h9poM0JLEh36nfLmlOhla9TF9W5PaDhuP7FKf4KSsOQ5RLAyJeOM9ar
+# JX1Y3q19u1Dp3i6DpBlzqxs91d5pHqHA1UZCZLQcwkWwuCjZknDuKtUWuJLI1bF2dvF6kl72CejWqm0E
+# fDzTCCWphHKOVK5I1bfBWMzoN0Fwn0F9sHjsygfFMhwURvaZHfRNh8fSV6stiksPc09dhAe1gqz2bWiv
+# kMT9lb16bxtQrfypXIpNOmNQs7O6EwpxhdEbxr7K7lsVyg36Zpo6hnFIKJxsf46Wb4ElrKUwGrGhWeLj
+# --------------------------------------------------------------------------------
+
+```


### PR DESCRIPTION
Fixes #5538.

Use the configured tab owner for group membership actions when the top user table is hidden. Both add and remove actions now use the correct identity, and refreshing the lists preserves the tab owner. The normal table-selection path is unchanged.

Validation:
- Client unit suite: 148 passed, 2 skipped.
- Ten focused click-handler tests cover additions, removals, refresh and stale hidden selections. Six fail against the original code.
- Main/test Checkstyle and the GWT application build pass.

Changelog generated with `log_change.sh`. A signed-in browser walkthrough was not performed.
