### PR TITLE
Highlight expired and soon-to-expire API keys

### DIFF
--- a/stroom-core-client/src/main/java/stroom/security/client/presenter/ApiKeyExpiryFormatter.java
+++ b/stroom-core-client/src/main/java/stroom/security/client/presenter/ApiKeyExpiryFormatter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stroom.security.client.presenter;
+
+import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+
+final class ApiKeyExpiryFormatter {
+
+    private static final long THIRTY_DAYS_MS = 30L * 24 * 60 * 60 * 1_000;
+
+    private ApiKeyExpiryFormatter() {
+    }
+
+    /// Formats an expiry date and indicates expired keys or expiry within 30 days.
+    ///
+    /// @param expireTimeMs the expiry instant, or null for a key without an expiry
+    /// @param nowMs the current time, supplied explicitly for consistent boundary tests
+    /// @param formattedDate the existing user-preference-aware date and duration text
+    /// @return escaped date text with a visible expiry status when appropriate
+    static SafeHtml format(final Long expireTimeMs, final long nowMs, final String formattedDate) {
+        final SafeHtmlBuilder builder = new SafeHtmlBuilder();
+        final String date = formattedDate == null ? "" : formattedDate;
+        if (expireTimeMs != null && expireTimeMs <= nowMs) {
+            builder.appendHtmlConstant("<em>Expired: ")
+                    .appendEscaped(date)
+                    .appendHtmlConstant("</em>");
+        } else if (expireTimeMs != null
+                   && (nowMs > Long.MAX_VALUE - THIRTY_DAYS_MS
+                       || expireTimeMs <= nowMs + THIRTY_DAYS_MS)) {
+            builder.appendHtmlConstant("<strong>Expires soon: ")
+                    .appendEscaped(date)
+                    .appendHtmlConstant("</strong>");
+        } else {
+            builder.appendEscaped(date);
+        }
+        return builder.toSafeHtml();
+    }
+}

--- a/stroom-core-client/src/main/java/stroom/security/client/presenter/ApiKeysListPresenter.java
+++ b/stroom-core-client/src/main/java/stroom/security/client/presenter/ApiKeysListPresenter.java
@@ -49,6 +49,7 @@ import stroom.widget.dropdowntree.client.view.QuickFilterUiHandlers;
 import stroom.widget.util.client.MultiSelectionModelImpl;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.user.cellview.client.Column;
 import com.google.gwt.view.client.Range;
 import com.google.inject.Inject;
@@ -344,12 +345,15 @@ public class ApiKeysListPresenter
         dataGrid.addColumn(enabledColumn, "State", ColumnSizeConstants.SMALL_COL);
 
         // Expires on
-        final Column<HashedApiKey, String> expiresOnColumn = DataGridUtil.textColumnBuilder(
-                        (HashedApiKey key) -> dateTimeFormatter.formatWithDuration(key.getExpireTimeMs()))
+        final Column<HashedApiKey, SafeHtml> expiresOnColumn = DataGridUtil.htmlColumnBuilder(
+                        (HashedApiKey key) -> ApiKeyExpiryFormatter.format(
+                                key.getExpireTimeMs(),
+                                System.currentTimeMillis(),
+                                dateTimeFormatter.formatWithDuration(key.getExpireTimeMs())))
                 .enabledWhen(HashedApiKey::getEnabled)
                 .withSorting(FindApiKeyCriteria.FIELD_EXPIRE_TIME)
                 .build();
-        dataGrid.addColumn(expiresOnColumn, "Expires On", ColumnSizeConstants.DATE_AND_DURATION_COL);
+        dataGrid.addResizableColumn(expiresOnColumn, "Expires On", ColumnSizeConstants.DATE_AND_DURATION_COL + 100);
         dataGrid.sort(expiresOnColumn);
 
         // Hash algorithm

--- a/stroom-core-client/src/test/java/stroom/security/client/presenter/TestApiKeyExpiryFormatter.java
+++ b/stroom-core-client/src/test/java/stroom/security/client/presenter/TestApiKeyExpiryFormatter.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stroom.security.client.presenter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestApiKeyExpiryFormatter {
+
+    private static final long NOW = 1_000_000_000_000L;
+    private static final long THIRTY_DAYS = 30L * 24 * 60 * 60 * 1_000;
+    private static final String DATE = "2026-09-10 (2 days)";
+
+    @Test
+    void testExpired() {
+        assertThat(ApiKeyExpiryFormatter.format(NOW - 1, NOW, DATE).asString())
+                .isEqualTo("<em>Expired: " + DATE + "</em>");
+    }
+
+    @Test
+    void testExpiryAtCurrentTime() {
+        assertThat(ApiKeyExpiryFormatter.format(NOW, NOW, DATE).asString())
+                .isEqualTo("<em>Expired: " + DATE + "</em>");
+    }
+
+    @Test
+    void testSoon() {
+        assertThat(ApiKeyExpiryFormatter.format(NOW + 1, NOW, DATE).asString())
+                .isEqualTo("<strong>Expires soon: " + DATE + "</strong>");
+        assertThat(ApiKeyExpiryFormatter.format(NOW + THIRTY_DAYS, NOW, DATE).asString())
+                .isEqualTo("<strong>Expires soon: " + DATE + "</strong>");
+    }
+
+    @Test
+    void testBeyondThirtyDays() {
+        assertThat(ApiKeyExpiryFormatter.format(NOW + THIRTY_DAYS + 1, NOW, DATE).asString())
+                .isEqualTo(DATE);
+    }
+
+    @Test
+    void testNoExpiry() {
+        assertThat(ApiKeyExpiryFormatter.format(null, NOW, DATE).asString()).isEqualTo(DATE);
+        assertThat(ApiKeyExpiryFormatter.format(null, NOW, null).asString()).isEmpty();
+    }
+
+    @Test
+    void testEscapingForEveryStatus() {
+        for (final Long expiry : new Long[]{NOW, NOW + 1, NOW + THIRTY_DAYS + 1, null}) {
+            assertThat(ApiKeyExpiryFormatter.format(expiry, NOW, "<script>&").asString())
+                    .contains("&lt;script&gt;&amp;")
+                    .doesNotContain("<script>");
+        }
+    }
+
+    @Test
+    void testNearMaximumTimestamp() {
+        assertThat(ApiKeyExpiryFormatter.format(Long.MAX_VALUE, Long.MAX_VALUE - 1, DATE).asString())
+                .startsWith("<strong>Expires soon: ");
+    }
+
+    @Test
+    void testDistantTimestampDoesNotOverflow() {
+        assertThat(ApiKeyExpiryFormatter.format(Long.MAX_VALUE, Long.MIN_VALUE, DATE).asString())
+                .isEqualTo(DATE);
+    }
+}

--- a/unreleased_changes/20260910_221315_304__5551.md
+++ b/unreleased_changes/20260910_221315_304__5551.md
@@ -1,0 +1,68 @@
+* Feature **#5551** : Distinguish expired API keys and keys expiring within 30 days using labels and formatting.
+
+
+```sh
+# ********************************************************************************
+# Issue number: 5551
+# Issue title:  Differential HIGHLIGHTING of date for expired ApiKeys
+# Issue tags:   f:ui / ux
+# Issue link:   https://github.com/gchq/stroom/issues/5551
+# ********************************************************************************
+
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Bug **#123** : Fix bug with an associated GitHub issue in this repository.
+#
+# * Bug **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository.
+#
+# * Feature **#789** : Add new feature X.
+#
+# * Bug : Fix bug with no associated GitHub issue.
+#
+#
+# Note: The line must start '* XXX ', where 'XXX' is a valid category,
+#       one of [Bug Feature Refactor Dependency Build].
+
+
+# --------------------------------------------------------------------------------
+# The following is random text to make this file unique for git's change detection
+# i8ZOyKdnGgaYANsTQMMC8VrgvsQASdnm2EPjnSiqTM2j5GDkxTtLn0bBvswq8YAx0kfMTeVY7QZy3SqD
+# 7ehvunZn3suR97niZBgmjSCKFFJm96sDPwGaPJsqJFL9a1fuQ5yF2k9hXHu6BCfH1CB1YHeCBNhdUMjP
+# 8b5UJvVUT7cCZ91NHoWX8CXlCqbxRMAJJGStJwxU1AZmP3AqoEPOvNqchaybBy6i8hsLwAF59bV4Tawq
+# kHrStsYRlBsZIHiKzKverAzlREugR47ljflLaKymhLcZpohwtu6aTrvA0UySjoV06vSeD3VulTtUL68j
+# 7kSsFRpZeP9eMJpqRwcZfg8y0TUk0JtzzM4nxg1eLKj6J7bh8pC75KiuhgZGP6iqqDpwICa1mGuIdzaI
+# jSXOmF06hA3eUUCbFDaak8Tiv575JBjfpRmyycaMXTZdPqXrOSFe9t7zgj3ORqUdktYKFiWnZkIzDKl9
+# AFdOzUnFUhY2kuhyvetIVsOKVU5E2a84tAXxLa28fNQADT9j01J6mCVPtVp74LbHhByqarXq5PzEGcKH
+# LTDrJCk5GNV9YtArYELe9hmlcJu5JbM7zt90v1OmMjV6k3MeepOElPhduu5dCrsRVgkbenhDaZmVVz04
+# 7RAr3LpWCI3XPhB2Z3aW4K2ntKubWaIqxbr9UdV73dLqWt0uMegwAuLZRlCeGRPF9ez33ofYLweQOLqC
+# KMTHXCrEbscrN0AMxgcbpEjwmYaj3ydLwqZjjQIpEY9NnCXDqbVNGYTHELPTsMz4tndGo3yhO3coVsqe
+# lG3jCSp87gLZhDsrK3k5fHiPRHec8Q6ruGjLZbHv0qgefFqomRGd7FkHKNXI2FdLP95Z4BtoIvzKHJay
+# uokytC1H3Obq0qR9oibm7Hc9OhLB2MpoDnzNXAYloW6W30Rnt7zEt6RdhSKzWeOcBU52t0OLeLNEm1EC
+# 876YXc5aE0HPeQiMDT2XdRRbFhFZwZ8C8qdLUFL7GxJIiH1NqdoK4kHu4PShoutRg4xc6WSBPh2JjJrY
+# FjpQQGIUtMGZ609eBAY6ZLNU9ICGIT9b6v947p6vutnkOZV6A1gOiD37iRE8L3MARKT1cUaC10Ww84s0
+# Pf2liofdaM3zBctUjd4PZ2OGtX6cj8QaNiRZA0mmijInP23puDIWBVspPjWvwntJxyPWhLQ5Zw8x3v3I
+# 1XvKfzBu57emel15Q8uDMhYYtIUXevtbTEmDclzXU2FiGPN0fc4PVf2vtsHR2KR842LJ0Sn1m45xeNey
+# 4ZkWendyHTHIiFs5xXit5VdV66sp1PYICnilHQ2fQWlgp1rixkcCf2ezaN8aEFDm2BNIGYSN2vx3CZEh
+# 88L3XfANLlK5q1fLaQWCrCirKrzx5oEPKuml8fSDpeofBo5ijtu5tX4i4cPLiSaiSFK1PLcDDNiWZNsT
+# cLj5RmUTVFV3KhJq48eroiL9FGIbna6I3WtJvaYlYxnDcrBZ68Yt51qUdT3ArRDEozhBnShnNIow7i1I
+# P5RY5jnYQZEL7aaKeTozSQhxQkgFx0rFmpBqlcQxQr4oDeO3z7zs2ApdmrWZVQXSvshIo86bt5gnVORj
+# oRKU5VxlMCwKZ0uKxGXd8fgeiGLHZ9dySZA3V0HA3gqiV42VsLEAtxOZV8Dembh3gOieQMtOAKpOonLX
+# mArdPBNlJE0XCx5ajJ8HqZDW8P2EiMU41yOXtt0XuPkvTGjkHBWwn1Dz8hWBfRhDfYeqZcTIytNdxEEP
+# NWYkcIDbxHFkvqvCutKLfrclk1iPNmCCgq5o63tHkxvifaWIkf7JAf7OSj5dw3o3FFNYyQMmI8asEHWj
+# edDCw7YcIQOjA7rASiU3sRwN6ie5uTsKroYytuMdxQ5eDCEhSqxNJKLDTr2zXPFONSVHuSuV7EHtYZiw
+# 8SWLTghuZWax6H1N7D6wpX23GKjoOTpBiLBwU4ULHdb6VrI361a7ofzGyFAUUi74GYlmKHFB4wAEaF1u
+# kXh6WAVncLpzlsM0AaOcPJ1b72ZinZveCX1tJ7Gh8zc2dNhaepTxPensEn4eW2a6jXcvwkHZ3GHP7Z27
+# LIOjCMKBTD76ngfn8nr63Xjx6DgMMqvOhc2k1FTW4XpHF32hwK1xaAZV9yVBM8xuIKfzwDwEu66G0WJe
+# s7OTCMhJH9EBv6EsyOsSQfQNIQO72mf1RvFRFNk10jiqDJlxPvr5PtvSBhi5tTV2kGqAwjhu6ZtZOt9d
+# kAUn1ebfSJIIxod6Fa513yS25CZfT5DNBbP1AFiGTlDElg5v9zuqTBzU3iCtUPXjPTGYirLybDvIK7pZ
+# QibWMUZgAjhwgJryVtssa6tNK2ACYZfdk7yWktECeyTsPR9IkQPe5cNmSDzCzgWIMlQOHJVHGC05jDH2
+# --------------------------------------------------------------------------------
+
+```


### PR DESCRIPTION
Fixes #5551.

Mark expired API keys in italics with an explicit "Expired" label, and keys expiring within 30 days in bold with "Expires soon". Preserve the existing date formatting, disabled-key styling and expiry sorting. The column is resizable to accommodate the status text.

Validation:
- 146 client tests passed, two skipped, including eight new expiry-formatting tests.
- Boundary coverage includes exact expiry, the 30-day cutoff, missing dates, timestamp overflow and HTML escaping.
- Main/test Checkstyle and the GWT application build passed.

Changelog included. Signed-in browser testing was not performed.
