### PR TITLE
Send CLI command output to stdout

### DIFF
--- a/stroom-app/src/main/java/stroom/app/commands/CreateAccountCommand.java
+++ b/stroom-app/src/main/java/stroom/app/commands/CreateAccountCommand.java
@@ -170,8 +170,8 @@ public class CreateAccountCommand extends AbstractStroomAppCommand {
         final boolean noPasswordChange = namespace.getBoolean(NO_PASSWORD_CHANGE);
         final boolean neverExpires = namespace.getBoolean(NEVER_EXPIRES_CHANGE_ARG_NAME);
 
-        LOGGER.info("Creating account for user '{}' - email '{}', first name '{}', last name '{}', " +
-                    "no password change '{}', never expires '{}'",
+        info(LOGGER, "Creating account for user '{}' - email '{}', first name '{}', last name '{}', " +
+                     "no password change '{}', never expires '{}'",
                 username, email, firstName, lastName, noPasswordChange, neverExpires);
 
         final CreateAccountRequest createAccountRequest = new CreateAccountRequest(

--- a/stroom-app/src/main/java/stroom/app/commands/CreateApiKeyCommand.java
+++ b/stroom-app/src/main/java/stroom/app/commands/CreateApiKeyCommand.java
@@ -154,7 +154,7 @@ public class CreateApiKeyCommand extends AbstractStroomAppCommand {
                             if (outputApiKey(response, outputPath)) {
                                 final String msg = LogUtil.message("API key successfully created for user '{}'",
                                         userId);
-                                LOGGER.info(msg);
+                                info(LOGGER, msg);
                                 System.exit(0);
                             } else {
                                 final String msg = LogUtil.message("API key for user '{}' could not be output",
@@ -186,7 +186,7 @@ public class CreateApiKeyCommand extends AbstractStroomAppCommand {
                 namespace.get(HASH_ALGORITHM_ARG_NAME),
                 HashAlgorithm.DEFAULT);
 
-        LOGGER.info("Creating API key for user '{}' using algorithm '{}'",
+        info(LOGGER, "Creating API key for user '{}' using algorithm '{}'",
                 userRef.toInfoString(),
                 hashAlgorithm.getDisplayValue());
 
@@ -226,7 +226,7 @@ public class CreateApiKeyCommand extends AbstractStroomAppCommand {
                 writer.close();
 
                 final File fileInfo = new File(path);
-                LOGGER.info("Wrote API key for user '{}' to file '{}'",
+                info(LOGGER, "Wrote API key for user '{}' to file '{}'",
                         createHashedApiKeyResponse.getHashedApiKey().getOwner().toInfoString(),
                         fileInfo.getAbsolutePath());
             } catch (final IOException e) {
@@ -240,7 +240,7 @@ public class CreateApiKeyCommand extends AbstractStroomAppCommand {
             }
         } else {
             // Output API key to standard out
-            LOGGER.info("Generated API key for user '{}': '{}'",
+            info(LOGGER, "Generated API key for user '{}': '{}'",
                     createHashedApiKeyResponse.getHashedApiKey().getOwner().toInfoString(),
                     createHashedApiKeyResponse.getApiKey());
         }

--- a/stroom-app/src/main/java/stroom/app/commands/DbMigrationCommand.java
+++ b/stroom-app/src/main/java/stroom/app/commands/DbMigrationCommand.java
@@ -67,7 +67,7 @@ public class DbMigrationCommand extends AbstractStroomBaseCommand {
         final Set<DataSource> dataSources = injector.getInstance(
                 Key.get(GuiceUtil.setOf(DataSource.class)));
 
-        LOGGER.info("Used {} data sources:\n{}",
+        info(LOGGER, "Used {} data sources:\n{}",
                 dataSources.size(),
                 dataSources.stream()
                         .map(dataSource -> dataSource instanceof DataSourceProxy

--- a/stroom-app/src/main/java/stroom/app/commands/ManageUsersCommand.java
+++ b/stroom-app/src/main/java/stroom/app/commands/ManageUsersCommand.java
@@ -207,7 +207,7 @@ public class ManageUsersCommand extends AbstractStroomAppCommand {
                     .withColumn(Column.of("Description", AppPermission::getDescription))
                     .build();
 
-            LOGGER.info("""
+            info(LOGGER, """
                             Valid application permission names:
                             {}
                             """,

--- a/stroom-app/src/main/java/stroom/app/commands/ResetPasswordCommand.java
+++ b/stroom-app/src/main/java/stroom/app/commands/ResetPasswordCommand.java
@@ -121,7 +121,7 @@ public class ResetPasswordCommand extends AbstractStroomAppCommand {
         accountDao.resetPassword(username, newPassword);
 
         final String msg = LogUtil.message("Password reset complete for user {}", username);
-        LOGGER.info(msg);
+        info(LOGGER, msg);
         logEvent(username, true, msg);
     }
 

--- a/stroom-app/src/test/java/stroom/app/commands/TestAbstractStroomBaseCommand.java
+++ b/stroom-app/src/test/java/stroom/app/commands/TestAbstractStroomBaseCommand.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stroom.app.commands;
+
+import stroom.config.app.Config;
+
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import io.dropwizard.core.setup.Bootstrap;
+import net.sourceforge.argparse4j.inf.Namespace;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ResourceLock("SYSTEM_OUT")
+class TestAbstractStroomBaseCommand {
+
+    @Test
+    void infoWritesFormattedMessageToStdout() {
+        final PrintStream originalOut = System.out;
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        try (final PrintStream printStream = new PrintStream(output, true, StandardCharsets.UTF_8)) {
+            System.setOut(printStream);
+            new TestCommand().writeInfo("Created {} for {}", "key", "user");
+        } finally {
+            System.setOut(originalOut);
+        }
+
+        final long standaloneLines = output.toString(StandardCharsets.UTF_8)
+                .lines()
+                .filter("Created key for user"::equals)
+                .count();
+        assertThat(standaloneLines).isOne();
+    }
+
+    private static final class TestCommand extends AbstractStroomBaseCommand {
+        private static final Logger LOGGER = LoggerFactory.getLogger(TestCommand.class);
+
+        private TestCommand() {
+            super(Path.of("test.yml"), "test", "test command");
+        }
+
+        private void writeInfo(final String template, final Object... args) {
+            info(LOGGER, template, args);
+        }
+
+        @Override
+        protected void runCommand(final Bootstrap<Config> bootstrap,
+                                  final Namespace namespace,
+                                  final Config config,
+                                  final Injector injector) {
+        }
+
+        @Override
+        protected Set<String> getArgumentNames() {
+            return Set.of();
+        }
+
+        @Override
+        protected Optional<Module> getChildInjectorModule() {
+            return Optional.empty();
+        }
+    }
+}

--- a/unreleased_changes/20260911_085900_571__5478.md
+++ b/unreleased_changes/20260911_085900_571__5478.md
@@ -1,0 +1,68 @@
+* Bug **#5478** : Send CLI command status output to stdout while retaining existing log messages.
+
+
+```sh
+# ********************************************************************************
+# Issue number: 5478
+# Issue title:  Change CLI commands to log to stdout
+# Issue tags:
+# Issue link:   https://github.com/gchq/stroom/issues/5478
+# ********************************************************************************
+
+# ONLY the top line will be included as a change entry in the CHANGELOG.
+# The entry should be in GitHub flavour markdown and should be written on a SINGLE
+# line with no hard breaks. You can have multiple change files for a single GitHub issue.
+# The  entry should be written in the imperative mood, i.e. 'Fix nasty bug' rather than
+# 'Fixed nasty bug'.
+#
+# Examples of acceptable entries are:
+#
+#
+# * Bug **#123** : Fix bug with an associated GitHub issue in this repository.
+#
+# * Bug **namespace/other-repo#456** : Fix bug with an associated GitHub issue in another repository.
+#
+# * Feature **#789** : Add new feature X.
+#
+# * Bug : Fix bug with no associated GitHub issue.
+#
+#
+# Note: The line must start '* XXX ', where 'XXX' is a valid category,
+#       one of [Bug Feature Refactor Dependency Build].
+
+
+# --------------------------------------------------------------------------------
+# The following is random text to make this file unique for git's change detection
+# Src7WagelteMMv5eJkjUEHLdZ3nTC2mtRRCIoBRepzr8ak0JjNzXoXcKAE3DISVUYuEruo98SuxC2Be6
+# VV0PLO964YGcKtc7fG2qH1ROkrdJSWeYBPyRyRlvWZyMJx3pSD1Gs2Ry5amY3v6FOrrSZvIX6yZlbuRv
+# 1IJky1K4TEwOJFNfkXiVcf28nLNXf6DBTCbc5trI1DtRzt3FYLGeamWekBJqNyds7OT1DPmfDj5BAqXB
+# nsbKGhPvNh7UBfmjBbnvxjmy5eBbudwer6jWPewbeIUZJ80neZfSYyRNytYys7SLL7RFBdwYo3hkXcRq
+# Um1AxFdXJPG3FvNCDmD0hlFhDru9Vv3rPIH6BacEnhm43LqMX2MJPL9SYatIRv3inG2u3u7HN7fD2Efu
+# aqsXJuD5VaOzoYo2tFiG5ZDWzDIdGRqcf9ijJFY71IqfPw2CQWXm7YlhJNbU0hgWujhepamAnUXwWuqu
+# yaUwvdZESxhEtJT3V0MIqy1vxtXqKsDzgqyCrIJ7VC7gBIZwKfs3wtlDDF9jVN8OPZ3uXwhTuRbmjv5c
+# YZuFJo47E4eNKYMgBajqusQ9StzfiZWxt35FSDFQxLLJW2t2qQ0hNmJVMGdRyhZsuqPNzpuFhEWaLpKU
+# Cy6DxjjlfSRF9vAEg9pJGZGSfckEj00VbzjgyYyI2QtG9ndqOez9cb3g1VHssBUJDPL3gSWoqm4xsOJM
+# FP63biv9sjV62aciqkkhedco2mN4DmeSXMBpo33wb47mhkm0caYGDADstrbUav1eR5ZMcGw8iLKAYz53
+# cCeCM6RwrxgmUDYZ4Ye2TwmJXACZj6WrNoPYBugl55B0TstsMi1DASTnKWB27bKCCra0LkYgKgwMnicF
+# y5xY6jxFXeIQcWHf7yYhzoUljn9f33RiymcePeCNvPEABNFgOu72C4NhOqxl9A57WxkysMEo3Fk6Nqoc
+# gS8I5CGSQYJoPXTfTxnNqiAoQGincyOSSftgcGoBjWRJsKVcG4lPLSGncJFYxWHoetalKeRGckZqs248
+# zeulzceeEBG2WwJbHrIAVeTcgYK8iz1cUPNTLeClRH0c9VEK0HNYifqvL43Qbr9AessM6syWZSIedZ4G
+# 4GUIxmhZutGZJSqjWK4uv0bMEPziRs2AZrBsJlaxYfEtepRaQlHOfIR8vRFDSES1HmbAZmkZoxaq9s1h
+# SMJgMZgcOuHLOAikAH8qZkJESu6NQPSOMXdnFdfzK94eUmfXl8s6PjqQ0dQWuKos9ti0TXFTtvUaHchp
+# 5hHa5BN4sEwN5Crn6PHpJfTqvZIpViAlKfZhW8Ld3u4RFCfNuUx7sWtaFf8lxxd6FQI9AqQrct5X0Pue
+# MLX5KYcD9EY4yxX4OmTjF09TF0Q6v9JqXavWlHeGTJDy9cWMHl2EaEt36jVwYt8vMpH8RxmLo4nfIwoa
+# ZsxXTN514qS4Vgotq50IphNY2b1Cpdu7HgGpK4S52qLHlI3x6lHBgIE65CfHvQ84uyN0nUv6VMeaWTj3
+# nYGn2J1sFr7gzla7QNJ4ocAYoGahLR3FX3ldZJulaqoLZFuynVgQATxEP5cn5M4dtJFmycPpeORL84SU
+# vl3jTmIou4mfUznG1742kX5BtYSTmp89vSqz72Co0bc7GPj7gAX2NPuqhTPAopo4i4cdE9Oa6V4neJKR
+# ECMiM4iSk07YqigIK6clXZhy0OTWTujF9WtoSMbGmtBq57JCui0F2HParQNIonHLRIk6KSWTmKAl58Eo
+# jdWhlYAS7kGJnh1PzP7eWhziaJrWBYyRqNaazfeV2ZQebbpGY8m7oy0nshy4xySjYM636b63gABuM0hH
+# BHCuIDew3jMCKtqm5uZ7JNDHQ5aMBMPthFKScVaZodUkfcEQdxySDoNQAbbXvZ4bz4YH1KWNyemPagoi
+# u13VYQlQkVs70esQKt4kz9gDoG4sz2MYAesneDBeyrpQJeHbDaxEfolhMQPKI9Vggl4NK4rghQkNsysq
+# WJT8eXyahJc80zNHCW7C8f5vnMaxtEjjSFdNoYugx3XeOkxsBvoiibj4VdQHV0RtiKUCN3ubF3pUf1HT
+# Fo0kUuXXxg0LYSPAJ80rOVCjHiSpDWYuJDKBL0z8l3WRphIFUXPuUVLbPZaCcUIGbSk88OjaqEwQMacj
+# lOnUt3K4jtRIOo9gmDRFP3X6jO9jfcNWarUpStgmhIukCGZHeMC6Swa7roUdzRhBxjq77B3YQE9Sg6d1
+# 2zqCtQuXkdjknuAMFyMk0dlCGWtg6oDBkkwHqqo5Y0iR27k6wBa5B8neTVN3QZHISGwse1RswdJraqvz
+# PAnODCgW4sufzx21YjzX9MO1qc42fq53gDS5c5sRLAzYgfCGOwv17quK0iHpRn63YogC7VeiL32TMmw1
+# --------------------------------------------------------------------------------
+
+```


### PR DESCRIPTION
Fixes #5478.

Route the remaining CLI status messages through the existing stdout-aware command helpers. The messages are still logged, while command users now receive the same status output directly on stdout.

This covers account creation, API-key creation, database migration, permission listing and password reset. API keys written to an output file remain file-only.

Validation:
- `TestAbstractStroomBaseCommand` passes and verifies formatted status output reaches stdout.
- `TestManageUsersCommand` passes.
- `stroom-app` Checkstyle passes for main and test sources.
- Changelog entry generated with `log_change.sh`.
