### PR TITLE
Fix incomplete rerank field handling

### DIFF
--- a/stroom-index/stroom-index-lucene/src/main/java/stroom/index/lucene/RerankScoringFilterFactoryImpl.java
+++ b/stroom-index/stroom-index-lucene/src/main/java/stroom/index/lucene/RerankScoringFilterFactoryImpl.java
@@ -121,7 +121,7 @@ public class RerankScoringFilterFactoryImpl implements RerankScoringFilterFactor
                 final String denseVectorFieldName = entry.getKey();
                 final FieldRef fieldRef = entry.getValue();
 
-                if (fieldRef.scoreField.index != -1 && fieldRef.valueField.index != -1) {
+                if (fieldRef.scoreField != null && fieldRef.valueField != null) {
                     final IndexField denseVectorField = indexFieldCache.get(indexDocRef, denseVectorFieldName);
                     if (denseVectorField == null) {
                         throw new UnsupportedOperationException(

--- a/stroom-index/stroom-index-lucene/src/test/java/stroom/index/lucene/TestRerankScoringFilterFactoryImpl.java
+++ b/stroom-index/stroom-index-lucene/src/test/java/stroom/index/lucene/TestRerankScoringFilterFactoryImpl.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stroom.index.lucene;
+
+import org.junit.jupiter.api.Test;
+
+import stroom.ai.api.AiService;
+import stroom.ai.api.OpenAIModelStore;
+import stroom.query.common.v2.IndexFieldCache;
+import stroom.query.language.functions.FieldIndex;
+import stroom.query.language.functions.ref.ErrorConsumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class TestRerankScoringFilterFactoryImpl {
+
+    private final IndexFieldCache indexFieldCache = mock(IndexFieldCache.class);
+    private final ErrorConsumer errorConsumer = mock(ErrorConsumer.class);
+    private final RerankScoringFilterFactoryImpl factory = new RerankScoringFilterFactoryImpl(
+            indexFieldCache,
+            mock(OpenAIModelStore.class),
+            mock(AiService.class));
+
+    @Test
+    void shouldIgnoreRerankValueFieldWithoutScoreField() {
+        final FieldIndex fieldIndex = new FieldIndex();
+        fieldIndex.create("Vector__rerank_value");
+
+        assertThat(factory.create(null, null, fieldIndex, null, errorConsumer)).isEmpty();
+        verifyNoInteractions(indexFieldCache, errorConsumer);
+    }
+
+    @Test
+    void shouldIgnoreRerankScoreFieldWithoutValueField() {
+        final FieldIndex fieldIndex = new FieldIndex();
+        fieldIndex.create("Vector__rerank_score");
+
+        assertThat(factory.create(null, null, fieldIndex, null, errorConsumer)).isEmpty();
+        verifyNoInteractions(indexFieldCache, errorConsumer);
+    }
+}

--- a/unreleased_changes/20260912_182710_486__5773.md
+++ b/unreleased_changes/20260912_182710_486__5773.md
@@ -1,0 +1,1 @@
+* Bug **#5773** : Avoid rerank errors when a helper field is absent.


### PR DESCRIPTION
Fixes #5773.

## Summary

Avoid dereferencing incomplete rerank helper-field pairs when a query contains only the generated score field or only the generated value field.

`RerankScoringFilterFactoryImpl` can build a `FieldRef` with one side absent, then previously accessed `.index` on both sides unconditionally. The factory now proceeds only when both helper fields are present.

## Tests

- Added regressions for a rerank value field without its score field and a rerank score field without its value field.
- `./gradlew :stroom-index:stroom-index-lucene:test --tests stroom.index.lucene.TestRerankScoringFilterFactoryImpl --console=plain` with Java 25: passed.
- `git diff --check`: passed.

## Changelog

Added the required unreleased bug entry for #5773.
